### PR TITLE
feat: push notification infrastructure (#36)

### DIFF
--- a/app/api/push/send/route.ts
+++ b/app/api/push/send/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sendToUser, sendPushNotification } from "@/lib/push";
+import { serviceClient } from "@/lib/supabase/service";
+import type { PushPayload } from "@/lib/push";
+
+/**
+ * POST /api/push/send — send a push notification (admin/internal only).
+ *
+ * Auth: Bearer token must equal SUPABASE_SERVICE_ROLE_KEY.
+ *
+ * Body:
+ *   { userId?: string, payload: PushPayload }
+ *
+ * If userId is omitted, broadcasts to all subscribed users.
+ *
+ * Called by:
+ *   - Admin UI (manual sends)
+ *   - Future survey cron triggers:
+ *       • Survey goes live → broadcast to all
+ *       • Survey closing in 1 hour → broadcast to all
+ *       • Results published → broadcast to all
+ */
+export async function POST(req: NextRequest) {
+  const authHeader = req.headers.get("authorization") ?? "";
+  const token = authHeader.replace(/^Bearer\s+/i, "");
+
+  if (token !== process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body: { userId?: string; payload: PushPayload } = await req.json();
+  const { userId, payload } = body;
+
+  if (userId) {
+    await sendToUser(userId, payload);
+  } else {
+    // Broadcast to all subscribers
+    const { data: subscriptions, error } = await serviceClient
+      .from("push_subscriptions")
+      .select("endpoint, p256dh, auth_key");
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    await Promise.allSettled(
+      (subscriptions ?? []).map((sub) => sendPushNotification(sub, payload))
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/push/subscribe/route.ts
+++ b/app/api/push/subscribe/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import type { Database } from "@/lib/supabase/types";
+
+type PushSubscriptionInsert =
+  Database["public"]["Tables"]["push_subscriptions"]["Insert"];
+
+type SubscribeBody = {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+};
+
+/** POST /api/push/subscribe — save a push subscription for the authenticated user. */
+export async function POST(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body: SubscribeBody = await req.json();
+  const { endpoint, keys } = body;
+
+  const record: PushSubscriptionInsert = {
+    user_id: user.id,
+    endpoint,
+    p256dh: keys.p256dh,
+    auth_key: keys.auth,
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase.from("push_subscriptions") as any).upsert(
+    [record],
+    { onConflict: "endpoint" }
+  );
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+
+/** DELETE /api/push/subscribe — remove a push subscription by endpoint. */
+export async function DELETE(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { endpoint }: { endpoint: string } = await req.json();
+
+  const { error } = await supabase
+    .from("push_subscriptions")
+    .delete()
+    .eq("endpoint", endpoint)
+    .eq("user_id", user.id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/lib/push.ts
+++ b/lib/push.ts
@@ -1,0 +1,75 @@
+import webpush from "web-push";
+import { serviceClient } from "@/lib/supabase/service";
+
+webpush.setVapidDetails(
+  "mailto:langermank@gmail.com",
+  process.env.VAPID_PUBLIC_KEY!,
+  process.env.VAPID_PRIVATE_KEY!
+);
+
+export type PushSubscriptionRecord = {
+  endpoint: string;
+  p256dh: string;
+  auth_key: string;
+};
+
+export type PushPayload = {
+  title: string;
+  body: string;
+  url?: string;
+};
+
+/** Send a push notification to one subscription. Deletes dead (410) subscriptions. */
+export async function sendPushNotification(
+  subscription: PushSubscriptionRecord,
+  payload: PushPayload
+): Promise<void> {
+  try {
+    await webpush.sendNotification(
+      {
+        endpoint: subscription.endpoint,
+        keys: {
+          p256dh: subscription.p256dh,
+          auth: subscription.auth_key,
+        },
+      },
+      JSON.stringify(payload)
+    );
+  } catch (err: unknown) {
+    const status = (err as { statusCode?: number }).statusCode;
+    if (status === 410) {
+      // Subscription expired — remove from DB
+      await serviceClient
+        .from("push_subscriptions")
+        .delete()
+        .eq("endpoint", subscription.endpoint);
+    } else {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Fan out a push notification to all subscriptions for a user.
+ *
+ * Notification triggers (not yet wired to cron):
+ *   - Survey live → call sendToUser for every user
+ *   - Survey closing in 1 hour → call sendToUser for every user
+ *   - Results published → call sendToUser for every user
+ */
+export async function sendToUser(
+  userId: string,
+  payload: PushPayload
+): Promise<void> {
+  const { data: subscriptions, error } = await serviceClient
+    .from("push_subscriptions")
+    .select("endpoint, p256dh, auth_key")
+    .eq("user_id", userId);
+
+  if (error) throw error;
+  if (!subscriptions?.length) return;
+
+  await Promise.allSettled(
+    subscriptions.map((sub) => sendPushNotification(sub, payload))
+  );
+}

--- a/lib/supabase/service.ts
+++ b/lib/supabase/service.ts
@@ -1,0 +1,8 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+
+/** Service-role Supabase client. Server-only — bypasses RLS. Never expose to the browser. */
+export const serviceClient = createClient<Database>(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);


### PR DESCRIPTION
## Summary
- `lib/supabase/service.ts` — service-role Supabase client (bypasses RLS, server-only)
- `lib/push.ts` — `sendPushNotification` + `sendToUser` using `web-push` + VAPID; dead subscriptions (410) auto-deleted
- `app/api/push/subscribe/route.ts` — POST (upsert subscription) + DELETE (remove by endpoint), auth-gated
- `app/api/push/send/route.ts` — POST broadcast/targeted send, gated by `SUPABASE_SERVICE_ROLE_KEY` Bearer token

## New env vars needed
- `VAPID_PUBLIC_KEY`
- `VAPID_PRIVATE_KEY`
- `SUPABASE_SERVICE_ROLE_KEY`

## Test plan
- [ ] POST `/api/push/subscribe` with valid session → 200, row appears in `push_subscriptions`
- [ ] POST `/api/push/subscribe` unauthenticated → 401
- [ ] DELETE `/api/push/subscribe` with valid session → 200, row removed
- [ ] POST `/api/push/send` with correct Bearer token + userId → notification delivered
- [ ] POST `/api/push/send` with no userId → broadcast to all subscribers
- [ ] POST `/api/push/send` with wrong token → 401
- [ ] Dead subscription (410 from push service) → auto-deleted from DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)