### PR TITLE
chore: allowlist supabase commands for Claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,19 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(supabase status)",
+      "Bash(supabase status:*)",
+      "Bash(supabase start)",
+      "Bash(supabase start:*)",
+      "Bash(supabase stop)",
+      "Bash(supabase stop:*)",
+      "Bash(supabase db reset)",
+      "Bash(supabase db reset:*)",
+      "Bash(supabase db diff:*)",
+      "Bash(supabase migration new:*)",
+      "Bash(supabase migration list:*)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary
- Adds `supabase` CLI commands to `.claude/settings.json` permissions allowlist so Claude can manage local DB lifecycle (status, start, stop, db reset, db diff, migration new, migration list) without permission prompts.

## Why
Pairs with a new feedback memory: Claude should proactively run `supabase status` / `supabase db reset` at session start, after writing migrations, and after pulls — so I don't have to remember when to run them.

## Test plan
- [ ] Open a new Claude Code session; confirm `supabase status` runs without a permission prompt