### PR TITLE
Contestant detail page + dark mode regression fix

### DIFF
--- a/app/(app)/market/MarketClient.tsx
+++ b/app/(app)/market/MarketClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { derivePrice, type PricingParams } from "@/lib/pricing";
 import { useContestantPrices } from "@/hooks/useContestantPrices";
 import type { ContestantStatus, SeasonStatus } from "@/lib/supabase/types";
@@ -144,6 +145,7 @@ export function MarketClient({
   const { prices, isLoading } = useContestantPrices(season.id, pricingParams);
   const priceMap = season.status === "active" && prices.size > 0 ? prices : initialPrices;
   const isPreSeason = season.status === "pre_season";
+  const router = useRouter();
 
   return (
     <div className="mx-auto flex min-h-full max-w-3xl flex-col px-4 py-6">
@@ -206,6 +208,7 @@ export function MarketClient({
                 <li key={contestant.id}>
                   <button
                     type="button"
+                    onClick={() => router.push(`/market/${contestant.id}`)}
                     className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-emerald-500"
                   >
                     <span className="flex min-w-0 items-center gap-3">

--- a/app/(app)/market/[id]/ContestantDetailClient.tsx
+++ b/app/(app)/market/[id]/ContestantDetailClient.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { derivePrice, sellProceeds, type PricingParams } from "@/lib/pricing";
+import { useContestantPrices } from "@/hooks/useContestantPrices";
+import type { MarketContestant, MarketSeason } from "../MarketClient";
+
+type Holding = {
+  shares_held: string;
+  average_purchase_price: string;
+} | null;
+
+type Trade = {
+  price_at_execution: string;
+  created_at: string;
+};
+
+type SlimContestant = {
+  id: string;
+  total_shares_outstanding: string;
+};
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function initialsFor(name: string): string {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+}
+
+function PriceChart({ trades }: { trades: Trade[] }) {
+  if (trades.length < 2) {
+    return (
+      <div className="flex h-36 items-center justify-center rounded-lg border border-neutral-800 bg-neutral-950">
+        <p className="text-sm text-neutral-500">No price history yet</p>
+      </div>
+    );
+  }
+
+  const prices = trades.map((t) => parseFloat(t.price_at_execution));
+  const minPrice = Math.min(...prices);
+  const maxPrice = Math.max(...prices);
+  const range = maxPrice - minPrice || 0.01;
+
+  const W = 100;
+  const H = 50;
+  const PAD_Y = 3;
+
+  const pts = prices.map((price, i) => ({
+    x: (i / (prices.length - 1)) * W,
+    y: PAD_Y + (1 - (price - minPrice) / range) * (H - PAD_Y * 2),
+  }));
+
+  const isUp = prices[prices.length - 1] >= prices[0];
+  const color = isUp ? "#34d399" : "#f87171";
+
+  const linePath = `M ${pts.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(" L ")}`;
+  const areaPath = `${linePath} L ${W},${H} L 0,${H} Z`;
+
+  return (
+    <div>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="none"
+        className="w-full h-36"
+        style={{ display: "block" }}
+      >
+        <defs>
+          <linearGradient id="chart-fill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity="0.25" />
+            <stop offset="100%" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path d={areaPath} fill="url(#chart-fill)" />
+        <path
+          d={linePath}
+          fill="none"
+          stroke={color}
+          strokeWidth="1.5"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+      <div className="flex justify-between px-1 mt-1">
+        <span className="text-[11px] text-neutral-500">{currency.format(minPrice)}</span>
+        <span className="text-[11px] text-neutral-500">{currency.format(maxPrice)}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function ContestantDetailClient({
+  contestant,
+  season,
+  holding,
+  trades,
+  allContestants,
+}: {
+  contestant: MarketContestant;
+  season: MarketSeason;
+  holding: Holding;
+  trades: Trade[];
+  allContestants: SlimContestant[];
+}) {
+  const basePrice = parseFloat(season.base_price);
+
+  const pricingParams = useMemo<PricingParams>(
+    () => ({
+      basePrice,
+      kConstant: parseFloat(season.k_constant),
+      minSupplyFloor: Math.max(allContestants.length, 1),
+    }),
+    [basePrice, season.k_constant, allContestants.length]
+  );
+
+  const initialPrices = useMemo(() => {
+    const sharesMap = new Map(
+      allContestants.map((c) => [c.id, parseFloat(c.total_shares_outstanding)])
+    );
+    const totalAllShares = Array.from(sharesMap.values()).reduce((s, v) => s + v, 0);
+    return new Map(
+      allContestants.map((c) => {
+        const shares = sharesMap.get(c.id) ?? 0;
+        return [
+          c.id,
+          {
+            sharesOutstanding: shares,
+            price: derivePrice(shares, totalAllShares, pricingParams),
+          },
+        ];
+      })
+    );
+  }, [allContestants, pricingParams]);
+
+  const { prices } = useContestantPrices(season.id, pricingParams);
+  const priceMap = prices.size > 0 ? prices : initialPrices;
+
+  const currentPrice =
+    season.status === "active"
+      ? (priceMap.get(contestant.id)?.price ?? basePrice)
+      : basePrice;
+
+  const sharesOutstanding =
+    priceMap.get(contestant.id)?.sharesOutstanding ??
+    parseFloat(contestant.total_shares_outstanding);
+
+  const totalAllShares = useMemo(
+    () => Array.from(priceMap.values()).reduce((s, v) => s + v.sharesOutstanding, 0),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [priceMap]
+  );
+
+  const sharesHeld = holding ? parseFloat(holding.shares_held) : 0;
+  const avgPurchasePrice = holding ? parseFloat(holding.average_purchase_price) : 0;
+
+  const liquidationValue = useMemo(() => {
+    if (sharesHeld <= 0) return 0;
+    return sellProceeds(sharesHeld, sharesOutstanding, totalAllShares, pricingParams).proceeds;
+  }, [sharesHeld, sharesOutstanding, totalAllShares, pricingParams]);
+
+  const priceDelta = currentPrice - basePrice;
+  const isPreSeason = season.status === "pre_season";
+
+  const statusLabel =
+    contestant.status !== "active" ? contestant.status.replace("_", " ") : null;
+
+  const flags = [
+    contestant.is_hoh ? "HoH" : null,
+    contestant.is_nominated ? "Nominated" : null,
+    contestant.has_veto ? "Veto" : null,
+  ].filter((f): f is string => Boolean(f));
+
+  return (
+    <div className="relative min-h-full bg-neutral-950">
+      {/* Sticky header */}
+      <div className="sticky top-0 z-10 flex items-center gap-3 border-b border-neutral-800 bg-neutral-950/95 px-4 py-3 backdrop-blur-sm">
+        <Link
+          href="/market"
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-neutral-400 transition-colors hover:text-neutral-100"
+          aria-label="Back to market"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M19 12H5M12 5l-7 7 7 7" />
+          </svg>
+        </Link>
+        <h1 className="flex-1 truncate text-center text-sm font-semibold text-neutral-100">
+          {contestant.name}
+        </h1>
+        <div className="w-8 shrink-0" aria-hidden="true" />
+      </div>
+
+      {/* Scrollable content */}
+      <div className="mx-auto max-w-3xl px-4 pt-6 pb-32">
+
+        {/* Identity */}
+        <div className="flex items-center gap-4">
+          <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-full bg-neutral-900 text-lg font-semibold text-neutral-300 ring-1 ring-neutral-800">
+            {contestant.photo_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={contestant.photo_url}
+                alt={contestant.name}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              initialsFor(contestant.name)
+            )}
+          </div>
+          <div className="min-w-0">
+            <p className="text-xl font-bold text-neutral-50">{contestant.name}</p>
+            <div className="mt-1.5 flex flex-wrap gap-1.5">
+              {statusLabel && (
+                <span className="rounded-full bg-neutral-800 px-2 py-0.5 text-[11px] font-medium capitalize text-neutral-300 ring-1 ring-neutral-700">
+                  {statusLabel}
+                </span>
+              )}
+              {flags.map((flag) => (
+                <span
+                  key={flag}
+                  className="rounded-full bg-neutral-800 px-2 py-0.5 text-[11px] font-medium text-neutral-300 ring-1 ring-neutral-700"
+                >
+                  {flag}
+                </span>
+              ))}
+              {!statusLabel && flags.length === 0 && (
+                <span className="text-xs text-neutral-500">Active</span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Live price */}
+        <div className="mt-6">
+          <p className="text-3xl font-bold tracking-tight text-neutral-50">
+            {currency.format(currentPrice)}
+          </p>
+          <p className="mt-1 text-sm">
+            {isPreSeason ? (
+              <span className="text-neutral-500">Starting price · read only</span>
+            ) : Math.abs(priceDelta) < 0.005 ? (
+              <span className="text-neutral-500">at base price</span>
+            ) : (
+              <span className={priceDelta > 0 ? "text-emerald-400" : "text-rose-400"}>
+                {priceDelta > 0 ? "+" : "−"}
+                {currency.format(Math.abs(priceDelta))} vs base
+              </span>
+            )}
+          </p>
+        </div>
+
+        {/* Price chart */}
+        <div className="mt-6">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-neutral-500">
+            Price history
+          </p>
+          <PriceChart trades={trades} />
+        </div>
+
+        {/* Holding */}
+        <div className="mt-6">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-neutral-500">
+            Your position
+          </p>
+          <div className="rounded-lg border border-neutral-800 bg-neutral-950 p-4">
+            {sharesHeld > 0 ? (
+              <dl className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <dt className="text-sm text-neutral-400">Shares held</dt>
+                  <dd className="text-sm font-semibold text-neutral-100">
+                    {sharesHeld.toFixed(4)}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <dt className="text-sm text-neutral-400">Avg buy price</dt>
+                  <dd className="text-sm font-semibold text-neutral-100">
+                    {currency.format(avgPurchasePrice)}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between border-t border-neutral-800 pt-3">
+                  <dt className="text-sm text-neutral-400">Value now</dt>
+                  <dd className="text-sm font-bold text-neutral-50">
+                    {isPreSeason
+                      ? currency.format(sharesHeld * basePrice)
+                      : currency.format(liquidationValue)}
+                  </dd>
+                </div>
+              </dl>
+            ) : (
+              <p className="text-sm text-neutral-500">
+                You don&apos;t own any shares in {contestant.name}.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Bio */}
+        {contestant.bio && (
+          <div className="mt-6">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-neutral-500">
+              About
+            </p>
+            <p className="text-sm leading-6 text-neutral-400">{contestant.bio}</p>
+          </div>
+        )}
+      </div>
+
+      {/* Sticky CTAs — wired up in #38 */}
+      {!isPreSeason && (
+        <div className="fixed bottom-16 inset-x-0 z-10 border-t border-neutral-800 bg-neutral-950/95 px-4 py-3 backdrop-blur-sm">
+          <div className="mx-auto flex max-w-3xl gap-3">
+            <button
+              type="button"
+              disabled
+              className="flex-1 cursor-not-allowed rounded-lg bg-emerald-600 py-3 text-sm font-semibold text-white opacity-50"
+            >
+              Buy
+            </button>
+            <button
+              type="button"
+              disabled
+              className={[
+                "flex-1 cursor-not-allowed rounded-lg py-3 text-sm font-semibold",
+                sharesHeld > 0
+                  ? "bg-neutral-700 text-neutral-100 opacity-50"
+                  : "bg-neutral-800 text-neutral-500",
+              ].join(" ")}
+            >
+              Sell
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/market/[id]/page.tsx
+++ b/app/(app)/market/[id]/page.tsx
@@ -1,0 +1,69 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import ContestantDetailClient from "./ContestantDetailClient";
+import type { MarketContestant, MarketSeason } from "../MarketClient";
+
+export default async function ContestantDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: rawContestant } = await supabase
+    .from("contestants")
+    .select(
+      "id, season_id, name, photo_url, bio, status, is_hoh, is_nominated, has_veto, total_shares_outstanding"
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (!rawContestant) notFound();
+  const contestant = rawContestant as MarketContestant;
+
+  const { data: rawSeason } = await supabase
+    .from("seasons")
+    .select("id, name, status, start_date, starting_balance, k_constant, base_price")
+    .eq("id", contestant.season_id)
+    .in("status", ["active", "pre_season"])
+    .maybeSingle();
+
+  if (!rawSeason) notFound();
+  const season = rawSeason as MarketSeason;
+
+  const [holdingResult, tradesResult, allContestantsResult] = await Promise.all([
+    supabase
+      .from("holdings")
+      .select("shares_held, average_purchase_price")
+      .eq("contestant_id", id)
+      .eq("user_id", user.id)
+      .maybeSingle(),
+    supabase
+      .from("trades")
+      .select("price_at_execution, created_at")
+      .eq("contestant_id", id)
+      .eq("state", "filled")
+      .order("created_at", { ascending: true })
+      .limit(200),
+    supabase
+      .from("contestants")
+      .select("id, total_shares_outstanding")
+      .eq("season_id", season.id),
+  ]);
+
+  return (
+    <ContestantDetailClient
+      contestant={contestant}
+      season={season}
+      holding={holdingResult.data}
+      trades={tradesResult.data ?? []}
+      allContestants={allContestantsResult.data ?? []}
+    />
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,26 +1,6 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
## Summary
- New `/market/[id]` route closes out the remaining tasks on #37: sticky header, photo + status flags, live price + vs-base delta, SVG price-history chart from filled trades, holding card with live liquidation value, bio, and sticky Buy/Sell CTAs (disabled pending #38)
- Market list rows now navigate to the detail page via \`useRouter().push()\`
- Drive-by fix: \`globals.css\` had a \`body { background: var(--background) }\` rule whose light-mode default was overriding the \`bg-neutral-950\` Tailwind class on \`<body>\`. Users in light mode saw a white page with floating dark inputs (most visible on login). Removed the light-mode variables — the app is always-dark by design.

## Test plan
- [ ] Open \`/market\`, tap a contestant row → routes to \`/market/[id]\`
- [ ] Detail page shows: live price, color-coded vs-base delta, status/flag chips, price chart (or "No price history yet" empty state), holding card or "You don't own any shares" empty state, bio
- [ ] Buy/Sell CTAs render but are disabled
- [ ] Back arrow returns to \`/market\`
- [ ] Open \`/login\` in a light-mode browser — page background is dark, fields are readable, "Sign in" button is the white primary CTA

Closes https://github.com/langermank/reality-stock-watch-app/issues/37

🤖 Generated with [Claude Code](https://claude.com/claude-code)