### PR TITLE
Leaderboard page (season + all-time)

### DIFF
--- a/app/(app)/leaderboard/LeaderboardClient.tsx
+++ b/app/(app)/leaderboard/LeaderboardClient.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+export type Badge = { type: "top_3" | "top_10"; season: string };
+
+export type LeaderboardEntry = {
+  rank: number;
+  userId: string;
+  username: string;
+  avatarUrl: string | null;
+  netWorth: number;
+  isSelf: boolean;
+  badges: Badge[];
+};
+
+export type SeasonOption = { id: string; name: string };
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function initialsFor(name: string): string {
+  return name
+    .split(/[\s_]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normalize(rows: any): LeaderboardEntry[] {
+  if (!Array.isArray(rows)) return [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return rows.map((r: any) => ({
+    rank: Number(r.rank),
+    userId: r.user_id,
+    username: r.username,
+    avatarUrl: r.avatar_url ?? null,
+    netWorth: Number(r.net_worth),
+    isSelf: Boolean(r.is_self),
+    badges: Array.isArray(r.badges) ? r.badges : [],
+  }));
+}
+
+function badgeLabel(b: Badge): string {
+  const kind = b.type === "top_3" ? "Top 3" : "Top 10";
+  return `${kind} · ${b.season}`;
+}
+
+export function LeaderboardClient({
+  activeSeason,
+  completedSeasons,
+  initialEntries,
+  pageSize,
+}: {
+  activeSeason: SeasonOption | null;
+  completedSeasons: SeasonOption[];
+  initialEntries: LeaderboardEntry[];
+  pageSize: number;
+}) {
+  const [tab, setTab] = useState<"current" | "alltime">(
+    activeSeason ? "current" : "alltime"
+  );
+
+  return (
+    <div className="mx-auto flex min-h-full max-w-3xl flex-col px-4 py-6">
+      <header>
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-500">
+          Leaderboard
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold text-neutral-50">Standings</h1>
+      </header>
+
+      {/* Tabs — Current Season hidden once no season is active */}
+      <div className="mt-5 flex gap-6 border-b border-neutral-800">
+        {activeSeason && (
+          <TabButton active={tab === "current"} onClick={() => setTab("current")}>
+            Current Season
+          </TabButton>
+        )}
+        <TabButton active={tab === "alltime"} onClick={() => setTab("alltime")}>
+          All-Time
+        </TabButton>
+      </div>
+
+      {tab === "current" && activeSeason ? (
+        <CurrentSeasonTab
+          season={activeSeason}
+          initialEntries={initialEntries}
+          pageSize={pageSize}
+        />
+      ) : (
+        <AllTimeTab completedSeasons={completedSeasons} />
+      )}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        "-mb-px border-b-2 pb-3 text-sm font-semibold transition-colors",
+        active
+          ? "border-neutral-100 text-neutral-100"
+          : "border-transparent text-neutral-500 hover:text-neutral-300",
+      ].join(" ")}
+    >
+      {children}
+    </button>
+  );
+}
+
+function CurrentSeasonTab({
+  season,
+  initialEntries,
+  pageSize,
+}: {
+  season: SeasonOption;
+  initialEntries: LeaderboardEntry[];
+  pageSize: number;
+}) {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>(initialEntries);
+  const [search, setSearch] = useState("");
+  const [hasMore, setHasMore] = useState(initialEntries.length === pageSize);
+  const [loading, setLoading] = useState(false);
+  const [pinned, setPinned] = useState<LeaderboardEntry | null>(null);
+  const selfRowRef = useRef<HTMLLIElement | null>(null);
+
+  // Debounced search → reload from offset 0 with the query.
+  useEffect(() => {
+    const handle = setTimeout(async () => {
+      const supabase = createClient();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data } = await (supabase as any).rpc("get_leaderboard", {
+        p_season_id: season.id,
+        p_limit: pageSize,
+        p_offset: 0,
+        p_search: search.trim() || null,
+      });
+      const rows = normalize(data);
+      setEntries(rows);
+      setHasMore(rows.length === pageSize);
+    }, 250);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, season.id, pageSize]);
+
+  async function loadMore() {
+    setLoading(true);
+    try {
+      const supabase = createClient();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data } = await (supabase as any).rpc("get_leaderboard", {
+        p_season_id: season.id,
+        p_limit: pageSize,
+        p_offset: entries.length,
+        p_search: search.trim() || null,
+      });
+      const rows = normalize(data);
+      setEntries((prev) => [...prev, ...rows]);
+      setHasMore(rows.length === pageSize);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function findMe() {
+    // If the user's row is already on screen, just scroll + highlight it.
+    const onScreen = entries.find((e) => e.isSelf);
+    if (onScreen) {
+      setPinned(null);
+      selfRowRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      return;
+    }
+    const supabase = createClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data } = await (supabase as any).rpc("get_user_rank", {
+      p_season_id: season.id,
+    });
+    const rows = normalize(data);
+    setPinned(rows[0] ?? null);
+  }
+
+  return (
+    <div>
+      {/* Search + Find me */}
+      <div className="mt-5 flex gap-2">
+        <div className="relative flex-1">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="M21 21l-4.3-4.3" />
+          </svg>
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by username"
+            aria-label="Search by username"
+            className="w-full rounded-lg border border-neutral-800 bg-neutral-900 py-2.5 pl-9 pr-3 text-sm text-neutral-100 placeholder-neutral-600 focus:border-neutral-600 focus:outline-none"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={findMe}
+          className="shrink-0 rounded-lg border border-neutral-700 px-4 text-sm font-semibold text-neutral-200 transition-colors hover:bg-neutral-900"
+        >
+          Find me
+        </button>
+      </div>
+
+      {/* Pinned own row (when not already on screen) */}
+      {pinned && (
+        <div className="mt-4">
+          <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-neutral-500">
+            Your rank
+          </p>
+          <Row entry={pinned} highlight />
+        </div>
+      )}
+
+      {entries.length === 0 ? (
+        <div className="mt-6 rounded-lg border border-neutral-800 bg-neutral-950 p-6 text-center">
+          <p className="text-sm font-medium text-neutral-200">
+            {search.trim() ? `No players found for “${search.trim()}”` : "No players yet"}
+          </p>
+          <p className="mt-1.5 text-sm text-neutral-500">
+            {search.trim()
+              ? "Try a different username."
+              : "Be the first to trade and climb the board."}
+          </p>
+        </div>
+      ) : (
+        <ul className="mt-4 divide-y divide-neutral-800" role="list">
+          {entries.map((e) => (
+            <li key={e.userId} ref={e.isSelf ? selfRowRef : undefined}>
+              <Row entry={e} highlight={e.isSelf} />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {hasMore && (
+        <div className="mt-4 flex justify-center">
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={loading}
+            className="rounded-lg border border-neutral-700 px-5 py-2.5 text-sm font-semibold text-neutral-200 transition-colors hover:bg-neutral-900 disabled:opacity-50"
+          >
+            {loading ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({ entry, highlight }: { entry: LeaderboardEntry; highlight?: boolean }) {
+  return (
+    <div
+      className={[
+        "grid grid-cols-[2rem_auto_minmax(0,1fr)_auto] items-center gap-3 rounded-lg px-2 py-3",
+        highlight ? "bg-emerald-600/10 ring-1 ring-inset ring-emerald-600/40" : "",
+      ].join(" ")}
+    >
+      <span className="text-center text-sm font-semibold tabular-nums text-neutral-400">
+        {entry.rank}
+      </span>
+      <span className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-full bg-neutral-900 text-xs font-semibold text-neutral-300 ring-1 ring-neutral-800">
+        {entry.avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={entry.avatarUrl} alt="" className="h-full w-full object-cover" />
+        ) : (
+          initialsFor(entry.username)
+        )}
+      </span>
+      <span className="min-w-0">
+        <span className="flex items-center gap-1.5">
+          <span className="truncate text-sm font-medium text-neutral-100">
+            {entry.username}
+          </span>
+          {entry.isSelf && (
+            <span className="rounded bg-emerald-600/20 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-emerald-400">
+              You
+            </span>
+          )}
+        </span>
+        {entry.badges.length > 0 && (
+          <span className="mt-1 flex flex-wrap gap-1">
+            {entry.badges.map((b, i) => (
+              <span
+                key={i}
+                className="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-400"
+              >
+                {badgeLabel(b)}
+              </span>
+            ))}
+          </span>
+        )}
+      </span>
+      <span className="text-right text-sm font-semibold tabular-nums text-neutral-50">
+        {currency.format(entry.netWorth)}
+      </span>
+    </div>
+  );
+}
+
+function AllTimeTab({ completedSeasons }: { completedSeasons: SeasonOption[] }) {
+  const [seasonId, setSeasonId] = useState<string>(completedSeasons[0]?.id ?? "");
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!seasonId) {
+      setEntries([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from("season_results")
+        .select("user_id, final_rank, final_net_worth, profiles(username, avatar_url)")
+        .eq("season_id", seasonId)
+        .order("final_rank", { ascending: true });
+
+      if (cancelled) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rows = ((data ?? []) as any[]).map((r) => ({
+        rank: Number(r.final_rank),
+        userId: r.user_id,
+        username: r.profiles?.username ?? "Unknown",
+        avatarUrl: r.profiles?.avatar_url ?? null,
+        netWorth: Number(r.final_net_worth),
+        isSelf: false,
+        badges: [] as Badge[],
+      }));
+      setEntries(rows);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [seasonId]);
+
+  if (completedSeasons.length === 0) {
+    return (
+      <div className="mt-6 rounded-lg border border-neutral-800 bg-neutral-950 p-6 text-center">
+        <p className="text-sm font-medium text-neutral-200">No completed seasons yet</p>
+        <p className="mt-1.5 text-sm text-neutral-500">
+          The all-time leaderboard unlocks when a season ends.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mt-5">
+        <label htmlFor="alltime-season" className="sr-only">
+          Season
+        </label>
+        <select
+          id="alltime-season"
+          value={seasonId}
+          onChange={(e) => setSeasonId(e.target.value)}
+          className="rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 focus:border-neutral-600 focus:outline-none"
+        >
+          {completedSeasons.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {loading ? (
+        <p className="mt-6 text-center text-sm text-neutral-500">Loading…</p>
+      ) : entries.length === 0 ? (
+        <div className="mt-6 rounded-lg border border-neutral-800 bg-neutral-950 p-6 text-center">
+          <p className="text-sm font-medium text-neutral-200">No results for this season</p>
+        </div>
+      ) : (
+        <ul className="mt-4 divide-y divide-neutral-800" role="list">
+          {entries.map((e) => (
+            <li key={e.userId}>
+              <Row entry={e} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/leaderboard/page.tsx
+++ b/app/(app)/leaderboard/page.tsx
@@ -1,8 +1,69 @@
-export default function LeaderboardPage() {
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { LeaderboardClient, type LeaderboardEntry, type SeasonOption } from "./LeaderboardClient";
+
+const PAGE_SIZE = 25;
+
+export default async function LeaderboardPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  // Current (tradeable) season, if any.
+  const { data: activeSeason } = await supabase
+    .from("seasons")
+    .select("id, name")
+    .eq("status", "active")
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  // Completed seasons for the All-Time filter.
+  const { data: completed } = await supabase
+    .from("seasons")
+    .select("id, name")
+    .in("status", ["ended", "results_published"])
+    .order("created_at", { ascending: false });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const active = activeSeason as any | null;
+  const completedSeasons = (completed ?? []) as SeasonOption[];
+
+  let initialEntries: LeaderboardEntry[] = [];
+  if (active) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data } = await (supabase as any).rpc("get_leaderboard", {
+      p_season_id: active.id,
+      p_limit: PAGE_SIZE,
+      p_offset: 0,
+      p_search: null,
+    });
+    initialEntries = normalizeEntries(data);
+  }
+
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-semibold">Leaderboard</h1>
-      <p className="mt-2 text-neutral-400 text-sm">Rankings coming soon.</p>
-    </div>
+    <LeaderboardClient
+      activeSeason={active ? { id: active.id, name: active.name } : null}
+      completedSeasons={completedSeasons}
+      initialEntries={initialEntries}
+      pageSize={PAGE_SIZE}
+    />
   );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normalizeEntries(rows: any): LeaderboardEntry[] {
+  if (!Array.isArray(rows)) return [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return rows.map((r: any) => ({
+    rank: Number(r.rank),
+    userId: r.user_id,
+    username: r.username,
+    avatarUrl: r.avatar_url ?? null,
+    netWorth: Number(r.net_worth),
+    isSelf: Boolean(r.is_self),
+    badges: Array.isArray(r.badges) ? r.badges : [],
+  }));
 }

--- a/supabase/migrations/0005_leaderboard_read.sql
+++ b/supabase/migrations/0005_leaderboard_read.sql
@@ -1,0 +1,134 @@
+-- ============================================================
+-- Reality Stock Watch — Leaderboard read functions
+-- Issue #40
+-- ============================================================
+--
+-- portfolios RLS is own-row only (auth.uid() = user_id), so a client
+-- cannot read everyone's net_worth to build a ranking. These
+-- SECURITY DEFINER functions expose ONLY public ranking columns
+-- (rank, username, avatar, net_worth, badges) — never cash_balance —
+-- so the leaderboard works without loosening portfolios RLS.
+--
+-- Ranking is computed at query time over the cached portfolios.net_worth
+-- column (refreshed ~every 60s by the pg_cron job in 0003). Search
+-- filters the returned rows but rank still reflects true standing.
+-- ============================================================
+
+-- Badges for a user across all seasons, as a JSON array labelled with
+-- the season name (badges persist across seasons).
+CREATE OR REPLACE FUNCTION leaderboard_badges(p_user_id uuid)
+RETURNS jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object('type', b.type, 'season', s.name)
+      ORDER BY b.awarded_at
+    ),
+    '[]'::jsonb
+  )
+  FROM badges b
+  JOIN seasons s ON s.id = b.season_id
+  WHERE b.user_id = p_user_id;
+$$;
+
+-- ------------------------------------------------------------
+-- get_leaderboard: paginated current-season ranking.
+--   p_search filters displayed rows by username (rank preserved).
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION get_leaderboard(
+  p_season_id uuid,
+  p_limit     int DEFAULT 25,
+  p_offset    int DEFAULT 0,
+  p_search    text DEFAULT NULL
+)
+RETURNS TABLE (
+  rank      bigint,
+  user_id   uuid,
+  username  text,
+  avatar_url text,
+  net_worth numeric,
+  is_self   boolean,
+  badges    jsonb
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+  WITH ranked AS (
+    SELECT
+      RANK() OVER (ORDER BY po.net_worth DESC) AS rank,
+      po.user_id,
+      pr.username,
+      pr.avatar_url,
+      po.net_worth
+    FROM portfolios po
+    JOIN profiles pr ON pr.id = po.user_id
+    WHERE po.season_id = p_season_id
+  )
+  SELECT
+    r.rank,
+    r.user_id,
+    r.username,
+    r.avatar_url,
+    r.net_worth,
+    r.user_id = auth.uid() AS is_self,
+    leaderboard_badges(r.user_id) AS badges
+  FROM ranked r
+  WHERE p_search IS NULL
+     OR p_search = ''
+     OR r.username ILIKE '%' || p_search || '%'
+  ORDER BY r.rank, r.username
+  LIMIT GREATEST(p_limit, 0)
+  OFFSET GREATEST(p_offset, 0);
+$$;
+
+-- ------------------------------------------------------------
+-- get_user_rank: the caller's own row for the "Find me" shortcut,
+--   even when they fall outside the currently loaded page.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION get_user_rank(p_season_id uuid)
+RETURNS TABLE (
+  rank      bigint,
+  user_id   uuid,
+  username  text,
+  avatar_url text,
+  net_worth numeric,
+  is_self   boolean,
+  badges    jsonb
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+  WITH ranked AS (
+    SELECT
+      RANK() OVER (ORDER BY po.net_worth DESC) AS rank,
+      po.user_id,
+      pr.username,
+      pr.avatar_url,
+      po.net_worth
+    FROM portfolios po
+    JOIN profiles pr ON pr.id = po.user_id
+    WHERE po.season_id = p_season_id
+  )
+  SELECT
+    r.rank,
+    r.user_id,
+    r.username,
+    r.avatar_url,
+    r.net_worth,
+    true AS is_self,
+    leaderboard_badges(r.user_id) AS badges
+  FROM ranked r
+  WHERE r.user_id = auth.uid();
+$$;
+
+GRANT EXECUTE ON FUNCTION leaderboard_badges(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_leaderboard(uuid, int, int, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_user_rank(uuid) TO authenticated;


### PR DESCRIPTION
## Summary
Implements the leaderboard (#40) — now stacked directly on `main` since Phase 3 #37–39 are merged.

- **Current Season tab**: ranks players by cached `net_worth`, with username search, a "Find me" shortcut, and explicit load-more pagination. The logged-in user's row is highlighted with a "YOU" badge.
- **All-Time tab**: filters by completed season from `season_results` (shows an empty state until a season ends).
- **Tabs**: Current Season is hidden when no season is active, and All-Time becomes the default.
- **Badges**: shown per row, labelled with season name (persist across seasons).

### New migration — required, not optional
`portfolios` RLS is own-row only (`auth.uid() = user_id`), so a client **cannot** read everyone's net worth to build a ranking. Migration `0005` adds `SECURITY DEFINER` functions (`get_leaderboard`, `get_user_rank`) that return **only public columns** — rank, username, avatar, net_worth, badges — never `cash_balance`. Search filters the displayed rows while rank still reflects true standing.

⚠️ **Deploy step:** this migration is applied to **local** only. It needs to be applied to staging + prod (`supabase db push` or the migration workflow) before this works in those environments.

## Test plan
- [x] Current Season ranks 1–N by net worth; own row highlighted via the RPC's `auth.uid()`
- [x] Search filters by username and preserves true rank (e.g. `mike` → rank 3, not re-ranked to 1)
- [x] All-Time empty state ("unlocks when a season ends")
- [x] Production build + typecheck, no console errors
- [ ] Load-more (seed DB has 5 users < 25 page size — button correctly hidden), badges (none awarded in beta), and the find-me pinned row (current user always on the first page with 5 rows) couldn't be exercised locally; logic is in place

## Notes
- Reads the cached `portfolios.net_worth` column (refreshed ~60s by the pg_cron job from #35) — local values are stale since pg_cron doesn't run locally, but ranking/UX is unaffected.
- All-Time scoring is still TBD per the issue; this displays `final_rank` per completed season, which is all the data model stores for now.

Closes https://github.com/langermank/reality-stock-watch-app/issues/40

🤖 Generated with [Claude Code](https://claude.com/claude-code)