### PR TITLE
feat: port frozen reveal/ranking logic + aggregation (#64a, #64b)

### DIFF
--- a/lib/reveal/aggregate.ts
+++ b/lib/reveal/aggregate.ts
@@ -1,0 +1,93 @@
+// NEW (#64b): turn N fan ranking-submissions into one ordered, scored list.
+// Not frozen — written cleanly. Borda is the default; an alternate strategy
+// (e.g. average-rank) can be swapped via the `strategy` param.
+
+/**
+ * A single fan's ranking submission: an ordered list of contestant ids,
+ * best (position 0) first. Position in the array IS the submitted rank.
+ */
+export type RankingSubmission = {
+  /** Contestant ids in ranked order, index 0 = top pick. */
+  order: string[]
+}
+
+export type AggregateResult = {
+  contestantId: string
+  rank: number
+  score: number
+}
+
+/**
+ * A scoring strategy reduces all submissions to a per-contestant score.
+ * Higher score = better. Ranking (order by score desc) is applied afterward.
+ */
+export type AggregateStrategy = (submissions: RankingSubmission[]) => Map<string, number>
+
+/**
+ * Borda count: each submission awards `(N - position)` points to each
+ * contestant, where N is the number of contestants in that submission and
+ * position is the contestant's 0-indexed slot. Points are summed across all
+ * submissions. Top of a list of N earns N points, bottom earns 1.
+ */
+export const bordaStrategy: AggregateStrategy = (submissions) => {
+  const scores = new Map<string, number>()
+
+  for (const submission of submissions) {
+    const n = submission.order.length
+    submission.order.forEach((contestantId, position) => {
+      const points = n - position
+      scores.set(contestantId, (scores.get(contestantId) ?? 0) + points)
+    })
+  }
+
+  return scores
+}
+
+/**
+ * Average finishing position: `score` is the mean submitted rank (1-indexed),
+ * inverted so that higher = better (up = good for the chart). A contestant's
+ * mean position `p` becomes `(maxN + 1) - p`, where `maxN` is the largest
+ * submission length seen — keeping scores positive and comparable to Borda's
+ * "higher is better" convention.
+ */
+export const averageRankStrategy: AggregateStrategy = (submissions) => {
+  const sums = new Map<string, number>()
+  const counts = new Map<string, number>()
+  let maxN = 0
+
+  for (const submission of submissions) {
+    maxN = Math.max(maxN, submission.order.length)
+    submission.order.forEach((contestantId, position) => {
+      const rank = position + 1
+      sums.set(contestantId, (sums.get(contestantId) ?? 0) + rank)
+      counts.set(contestantId, (counts.get(contestantId) ?? 0) + 1)
+    })
+  }
+
+  const scores = new Map<string, number>()
+  for (const [contestantId, sum] of sums) {
+    const meanRank = sum / (counts.get(contestantId) ?? 1)
+    scores.set(contestantId, maxN + 1 - meanRank)
+  }
+
+  return scores
+}
+
+/**
+ * Aggregate fan submissions into a ranked, scored list.
+ *
+ * @param submissions one ordered ranking per fan
+ * @param strategy    scoring strategy (default: Borda points)
+ * @returns contestants ordered by score desc, with 1-indexed `rank`
+ */
+export function aggregate(
+  submissions: RankingSubmission[],
+  strategy: AggregateStrategy = bordaStrategy,
+): AggregateResult[] {
+  const scores = strategy(submissions)
+
+  return [...scores.entries()]
+    .map(([contestantId, score]) => ({ contestantId, score }))
+    .sort((a, b) => b.score - a.score || a.contestantId.localeCompare(b.contestantId))
+    .map((entry, index) => ({ ...entry, rank: index + 1 }))
+}

--- a/lib/reveal/fixtures.ts
+++ b/lib/reveal/fixtures.ts
@@ -1,0 +1,79 @@
+// Ported from big-brother-season-data-vis/src/lib/mockData.ts.
+// Typed fixtures for tests + the data seam's "now" path. 13 players, 7 weeks.
+// Preserves the original's exact shapes and values so parity tests are meaningful.
+
+import type { Player, PublicState, Week, WeekRanking } from './types'
+import { buildPublicState } from './rankings'
+
+export const mockSeason = {
+  id: 'season-30',
+  number: 30,
+  status: 'current' as const,
+}
+
+export const mockPlayers: Player[] = [
+  ['rachel', 'Rachel', '#f0445f', 'active', null],
+  ['ashley', 'Ashley', '#9b39d0', 'active', null],
+  ['will', 'Will', '#3d8b8b', 'active', null],
+  ['morgan', 'Morgan', '#58bf63', 'active', null],
+  ['ava', 'Ava', '#fb8f3d', 'active', null],
+  ['vince', 'Vince', '#8f1f12', 'active', null],
+  ['lauren', 'Lauren', '#ffe34a', 'active', null],
+  ['katherine', 'Katherine', '#e243d8', 'active', null],
+  ['mickey', 'Mickey', '#586ce5', 'active', null],
+  ['keanu', 'Keanu', '#a8732b', 'active', null],
+  ['kelley', 'Kelley', '#a9ffc2', 'eliminated', 7],
+  ['joey', 'Joey', '#f7b7b2', 'eliminated', 3],
+  ['jessica', 'Jessica', '#f8f1b4', 'eliminated', 5],
+].map(([id, name, color, status, eliminatedWeek]) => ({
+  id: String(id),
+  seasonId: mockSeason.id,
+  name: String(name),
+  color: String(color),
+  imageUrl: `/players/${String(id)}.svg`,
+  status: status as Player['status'],
+  eliminatedWeek: eliminatedWeek === null ? null : Number(eliminatedWeek),
+}))
+
+export const mockWeeks: Week[] = Array.from({ length: 7 }, (_, index) => {
+  const weekNumber = index + 1
+  return {
+    id: `week-${weekNumber}`,
+    seasonId: mockSeason.id,
+    weekNumber,
+    title: `Week ${weekNumber}`,
+    status: weekNumber === 7 ? 'current' : 'previous',
+    isPublished: true,
+  }
+})
+
+const weeklyOrders = [
+  ['rachel', 'morgan', 'lauren', 'mickey', 'ashley', 'katherine', 'will', 'joey', 'jessica', 'ava', 'vince', 'keanu', 'kelley'],
+  ['ava', 'rachel', 'mickey', 'morgan', 'will', 'joey', 'katherine', 'jessica', 'ashley', 'lauren', 'vince', 'kelley', 'keanu'],
+  ['ava', 'rachel', 'mickey', 'morgan', 'will', 'joey', 'ashley', 'jessica', 'katherine', 'lauren', 'vince', 'kelley'],
+  ['ava', 'rachel', 'ashley', 'will', 'lauren', 'jessica', 'katherine', 'vince', 'keanu', 'morgan', 'mickey', 'kelley'],
+  ['rachel', 'ava', 'ashley', 'will', 'lauren', 'morgan', 'jessica', 'vince', 'keanu', 'mickey', 'kelley'],
+  ['rachel', 'ava', 'will', 'katherine', 'lauren', 'keanu', 'vince', 'ashley', 'morgan', 'mickey', 'kelley'],
+  ['rachel', 'ashley', 'will', 'morgan', 'ava', 'vince', 'lauren', 'katherine', 'mickey', 'keanu', 'kelley'],
+]
+
+export const mockRankings: WeekRanking[] = weeklyOrders.map((order, index) => ({
+  weekId: `week-${index + 1}`,
+  weekNumber: index + 1,
+  entries: order.map((playerId, orderIndex) => ({
+    playerId,
+    rank: orderIndex + 1,
+    score: Math.round((100 - orderIndex * 5.7 + index * 1.3) * 10) / 10,
+    revealed: index + 1 < 7,
+  })),
+}))
+
+export const mockPublicState: PublicState = buildPublicState(
+  mockSeason,
+  mockWeeks,
+  mockPlayers,
+  mockRankings,
+  'week-7',
+  'week-7',
+  3,
+)

--- a/lib/reveal/rankings.test.ts
+++ b/lib/reveal/rankings.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildPublicState,
+  calculateMovements,
+  calculateStats,
+  calculateVisualRank,
+  getActivePlayersForWeek,
+  visibleEntriesForWeek,
+} from './rankings'
+import { mockPlayers, mockRankings, mockSeason, mockWeeks } from './fixtures'
+import {
+  aggregate,
+  averageRankStrategy,
+  bordaStrategy,
+  type RankingSubmission,
+} from './aggregate'
+
+// Expected values below were captured by running the ORIGINAL
+// big-brother-season-data-vis/src/lib/rankings.ts against its mockData.ts.
+// These tests lock our port to the original's exact behavior.
+
+describe('visibleEntriesForWeek — reveal gating (top-first, rank-ascending)', () => {
+  it('reveals the top `revealCount` entries of the current week, hides the rest', () => {
+    const visible = visibleEntriesForWeek(mockRankings, 7, 3).map((e) => ({
+      playerId: e.playerId,
+      rank: e.rank,
+      revealed: e.revealed,
+    }))
+
+    expect(visible).toEqual([
+      { playerId: 'rachel', rank: 1, revealed: true },
+      { playerId: 'ashley', rank: 2, revealed: true },
+      { playerId: 'will', rank: 3, revealed: true },
+      { playerId: 'morgan', rank: 4, revealed: false },
+      { playerId: 'ava', rank: 5, revealed: false },
+      { playerId: 'vince', rank: 6, revealed: false },
+      { playerId: 'lauren', rank: 7, revealed: false },
+      { playerId: 'katherine', rank: 8, revealed: false },
+      { playerId: 'mickey', rank: 9, revealed: false },
+      { playerId: 'keanu', rank: 10, revealed: false },
+      { playerId: 'kelley', rank: 11, revealed: false },
+    ])
+  })
+
+  it('respects pre-set `revealed: true` on entries even when revealCount is 0', () => {
+    // Week 6 fixtures already have revealed:true, so revealCount 0 still shows all.
+    const visible = visibleEntriesForWeek(mockRankings, 6, 0)
+    expect(visible.every((e) => e.revealed)).toBe(true)
+  })
+
+  it('orders entries by rank ascending regardless of input order', () => {
+    const ranks = visibleEntriesForWeek(mockRankings, 7, 3).map((e) => e.rank)
+    expect(ranks).toEqual([...ranks].sort((a, b) => a - b))
+  })
+})
+
+describe('getActivePlayersForWeek', () => {
+  it('excludes players eliminated on or before the week', () => {
+    // joey out wk3, jessica out wk5, kelley out wk7
+    expect(getActivePlayersForWeek(mockPlayers, 7).map((p) => p.id)).toEqual([
+      'rachel',
+      'ashley',
+      'will',
+      'morgan',
+      'ava',
+      'vince',
+      'lauren',
+      'katherine',
+      'mickey',
+      'keanu',
+    ])
+  })
+
+  it('keeps a player active in weeks before their eliminatedWeek', () => {
+    // kelley (eliminatedWeek 7) is still active in week 5
+    expect(getActivePlayersForWeek(mockPlayers, 5).map((p) => p.id)).toContain('kelley')
+  })
+})
+
+describe('calculateVisualRank', () => {
+  it('maps rank 1 to 1 and bottom rank to 11 across the active field', () => {
+    expect(calculateVisualRank(1, 11)).toBe(1)
+    expect(calculateVisualRank(11, 11)).toBe(11)
+  })
+
+  it('returns 1 when there is at most one active player', () => {
+    expect(calculateVisualRank(5, 1)).toBe(1)
+  })
+})
+
+describe('calculateMovements', () => {
+  it('computes rank, previousRank, movement, and visualRank for the selected week', () => {
+    expect(calculateMovements(7, mockRankings, mockPlayers)).toEqual([
+      { playerId: 'rachel', rank: 1, previousRank: 1, movement: 0, visualRank: 1 },
+      { playerId: 'ashley', rank: 2, previousRank: 8, movement: 6, visualRank: 2 },
+      { playerId: 'will', rank: 3, previousRank: 3, movement: 0, visualRank: 3 },
+      { playerId: 'morgan', rank: 4, previousRank: 9, movement: 5, visualRank: 4 },
+      { playerId: 'ava', rank: 5, previousRank: 2, movement: -3, visualRank: 5 },
+      { playerId: 'vince', rank: 6, previousRank: 7, movement: 1, visualRank: 6 },
+      { playerId: 'lauren', rank: 7, previousRank: 5, movement: -2, visualRank: 7 },
+      { playerId: 'katherine', rank: 8, previousRank: 4, movement: -4, visualRank: 8 },
+      { playerId: 'mickey', rank: 9, previousRank: 10, movement: 1, visualRank: 9 },
+      { playerId: 'keanu', rank: 10, previousRank: 6, movement: -4, visualRank: 10 },
+      { playerId: 'kelley', rank: 11, previousRank: 11, movement: 0, visualRank: 11 },
+    ])
+  })
+})
+
+describe('calculateStats', () => {
+  it('produces Most Improved / Most Consistent / Biggest Drop cards', () => {
+    expect(calculateStats(7, mockRankings, mockPlayers)).toEqual([
+      {
+        label: 'Most Improved',
+        playerId: 'ashley',
+        value: 'Ashley',
+        detail: 'Rose 6 spots this week',
+        tone: 'up',
+      },
+      {
+        label: 'Most Consistent',
+        playerId: 'rachel',
+        value: 'Rachel',
+        detail: 'Held the steadiest recent ranking arc',
+        tone: 'steady',
+      },
+      {
+        label: 'Biggest Drop',
+        playerId: 'katherine',
+        value: 'Katherine',
+        detail: 'Fell 4 spots this week',
+        tone: 'down',
+      },
+    ])
+  })
+})
+
+describe('buildPublicState — mid-reveal (week 7, revealCount 3)', () => {
+  const state = buildPublicState(
+    mockSeason,
+    mockWeeks,
+    mockPlayers,
+    mockRankings,
+    'week-7',
+    'week-7',
+    3,
+    'FIXED-TS',
+  )
+
+  it('marks all prior weeks fully revealed', () => {
+    const priorWeeks = state.rankings.filter((r) => r.weekNumber < 7)
+    expect(priorWeeks.every((r) => r.entries.every((e) => e.revealed))).toBe(true)
+  })
+
+  it('reveals only the top `revealCount` entries of the selected week', () => {
+    const week7 = state.rankings.find((r) => r.weekNumber === 7)!
+    expect(week7.entries.map((e) => ({ rank: e.rank, revealed: e.revealed }))).toEqual([
+      { rank: 1, revealed: true },
+      { rank: 2, revealed: true },
+      { rank: 3, revealed: true },
+      { rank: 4, revealed: false },
+      { rank: 5, revealed: false },
+      { rank: 6, revealed: false },
+      { rank: 7, revealed: false },
+      { rank: 8, revealed: false },
+      { rank: 9, revealed: false },
+      { rank: 10, revealed: false },
+      { rank: 11, revealed: false },
+    ])
+  })
+
+  it('passes through the reveal pointer verbatim', () => {
+    expect(state.reveal).toEqual({
+      seasonId: 'season-30',
+      currentWeekId: 'week-7',
+      selectedWeekId: 'week-7',
+      revealCount: 3,
+      updatedAt: 'FIXED-TS',
+    })
+  })
+
+  it('attaches movements and stats for the selected week', () => {
+    expect(state.movements).toEqual(calculateMovements(7, mockRankings, mockPlayers))
+    expect(state.stats).toEqual(calculateStats(7, mockRankings, mockPlayers))
+  })
+})
+
+describe('aggregate — Borda points (default strategy)', () => {
+  it('awards (N - position) points per submission and ranks by score desc', () => {
+    const submissions: RankingSubmission[] = [
+      { order: ['a', 'b', 'c'] }, // a:3 b:2 c:1
+      { order: ['b', 'a', 'c'] }, // b:3 a:2 c:1
+    ]
+    // a:5 b:5 c:2 -> tie between a,b broken by id (localeCompare): a before b
+    expect(aggregate(submissions)).toEqual([
+      { contestantId: 'a', score: 5, rank: 1 },
+      { contestantId: 'b', score: 5, rank: 2 },
+      { contestantId: 'c', score: 2, rank: 3 },
+    ])
+  })
+
+  it('sums points across many submissions to produce a clear winner', () => {
+    const submissions: RankingSubmission[] = [
+      { order: ['x', 'y', 'z'] },
+      { order: ['x', 'z', 'y'] },
+      { order: ['y', 'x', 'z'] },
+    ]
+    // x: 3+3+2 = 8, y: 2+1+3 = 6, z: 1+2+1 = 4
+    const result = aggregate(submissions)
+    expect(result).toEqual([
+      { contestantId: 'x', score: 8, rank: 1 },
+      { contestantId: 'y', score: 6, rank: 2 },
+      { contestantId: 'z', score: 4, rank: 3 },
+    ])
+  })
+
+  it('handles a single submission (ranks mirror the submitted order)', () => {
+    expect(aggregate([{ order: ['p', 'q', 'r'] }])).toEqual([
+      { contestantId: 'p', score: 3, rank: 1 },
+      { contestantId: 'q', score: 2, rank: 2 },
+      { contestantId: 'r', score: 1, rank: 3 },
+    ])
+  })
+
+  it('returns an empty list for no submissions', () => {
+    expect(aggregate([])).toEqual([])
+  })
+
+  it('bordaStrategy is the default', () => {
+    const submissions: RankingSubmission[] = [{ order: ['a', 'b'] }]
+    expect(aggregate(submissions)).toEqual(aggregate(submissions, bordaStrategy))
+  })
+})
+
+describe('aggregate — average-rank strategy (swappable)', () => {
+  it('ranks by mean finishing position (lower mean = better), inverted for score', () => {
+    const submissions: RankingSubmission[] = [
+      { order: ['a', 'b', 'c'] }, // a:1 b:2 c:3
+      { order: ['b', 'a', 'c'] }, // b:1 a:2 c:3
+    ]
+    // mean ranks: a 1.5, b 1.5, c 3. maxN=3 -> score = 4 - mean
+    const result = aggregate(submissions, averageRankStrategy)
+    expect(result).toEqual([
+      { contestantId: 'a', score: 2.5, rank: 1 },
+      { contestantId: 'b', score: 2.5, rank: 2 },
+      { contestantId: 'c', score: 1, rank: 3 },
+    ])
+  })
+})

--- a/lib/reveal/rankings.ts
+++ b/lib/reveal/rankings.ts
@@ -1,0 +1,207 @@
+// Ported verbatim from big-brother-season-data-vis/src/lib/rankings.ts.
+// FROZEN: behavior-preserving port. Do not redesign, rename, or "improve".
+// Locked by parity tests in rankings.test.ts.
+
+import type {
+  Player,
+  PlayerMovement,
+  PublicState,
+  RankingEntry,
+  StatCard,
+  Week,
+  WeekRanking,
+} from './types'
+
+export function entriesForWeek(rankings: WeekRanking[], weekNumber: number) {
+  return rankings.find((ranking) => ranking.weekNumber === weekNumber)?.entries ?? []
+}
+
+export function visibleEntriesForWeek(
+  rankings: WeekRanking[],
+  weekNumber: number,
+  revealCount: number,
+) {
+  return entriesForWeek(rankings, weekNumber)
+    .slice()
+    .sort((a, b) => a.rank - b.rank)
+    .map((entry, index) => ({
+      ...entry,
+      revealed: index < revealCount || entry.revealed,
+    }))
+}
+
+export function getActivePlayersForWeek(players: Player[], weekNumber: number) {
+  return players.filter(
+    (player) => player.eliminatedWeek === null || player.eliminatedWeek > weekNumber,
+  )
+}
+
+export function calculateVisualRank(rank: number, activeCount: number) {
+  if (activeCount <= 1) {
+    return 1
+  }
+
+  return 1 + ((rank - 1) / (activeCount - 1)) * 10
+}
+
+export function calculateMovement(
+  playerId: string,
+  weekNumber: number,
+  rankings: WeekRanking[],
+  players: Player[],
+) {
+  const currentEntries = entriesForWeek(rankings, weekNumber)
+  const previousEntries = entriesForWeek(rankings, weekNumber - 1)
+  const current = currentEntries.find((entry) => entry.playerId === playerId)
+  const previous = previousEntries.find((entry) => entry.playerId === playerId)
+
+  if (!current || !previous) {
+    return 0
+  }
+
+  const removedAbove = previousEntries.filter((entry) => {
+    const player = players.find((candidate) => candidate.id === entry.playerId)
+    return (
+      entry.rank < previous.rank &&
+      player?.eliminatedWeek !== null &&
+      player?.eliminatedWeek === weekNumber
+    )
+  }).length
+
+  const expectedRank = previous.rank - removedAbove
+  return expectedRank - current.rank
+}
+
+export function calculateMovements(
+  selectedWeekNumber: number,
+  rankings: WeekRanking[],
+  players: Player[],
+): PlayerMovement[] {
+  const entries = entriesForWeek(rankings, selectedWeekNumber).slice().sort((a, b) => a.rank - b.rank)
+  const previousEntries = entriesForWeek(rankings, selectedWeekNumber - 1)
+  const activeCount = Math.max(entries.length, 1)
+
+  return entries.map((entry) => ({
+    playerId: entry.playerId,
+    rank: entry.rank,
+    previousRank: previousEntries.find((previous) => previous.playerId === entry.playerId)?.rank ?? null,
+    movement: calculateMovement(entry.playerId, selectedWeekNumber, rankings, players),
+    visualRank: calculateVisualRank(entry.rank, activeCount),
+  }))
+}
+
+function playerName(players: Player[], playerId: string | null) {
+  return players.find((player) => player.id === playerId)?.name ?? 'No data'
+}
+
+export function calculateStats(
+  selectedWeekNumber: number,
+  rankings: WeekRanking[],
+  players: Player[],
+): StatCard[] {
+  const movements = calculateMovements(selectedWeekNumber, rankings, players)
+  const improved = movements.reduce<PlayerMovement | null>(
+    (best, movement) => (best === null || movement.movement > best.movement ? movement : best),
+    null,
+  )
+  const dropped = movements.reduce<PlayerMovement | null>(
+    (worst, movement) => (worst === null || movement.movement < worst.movement ? movement : worst),
+    null,
+  )
+
+  const recentWeeks = rankings
+    .filter((ranking) => ranking.weekNumber <= selectedWeekNumber)
+    .slice(-4)
+
+  const consistency = players
+    .map((player) => {
+      const ranks = recentWeeks
+        .map((ranking) => ranking.entries.find((entry) => entry.playerId === player.id)?.rank)
+        .filter((rank): rank is number => typeof rank === 'number')
+
+      if (ranks.length < 2) {
+        return null
+      }
+
+      const average = ranks.reduce((sum, rank) => sum + rank, 0) / ranks.length
+      const variance =
+        ranks.reduce((sum, rank) => sum + Math.abs(rank - average), 0) / ranks.length
+      return { playerId: player.id, variance, bestRank: Math.min(...ranks) }
+    })
+    .filter((entry): entry is { playerId: string; variance: number; bestRank: number } => entry !== null)
+    .sort((a, b) => a.variance - b.variance || a.bestRank - b.bestRank)[0]
+
+  return [
+    {
+      label: 'Most Improved',
+      playerId: improved?.playerId ?? null,
+      value: playerName(players, improved?.playerId ?? null),
+      detail:
+        improved && improved.movement > 0
+          ? `Rose ${improved.movement} ${improved.movement === 1 ? 'spot' : 'spots'} this week`
+          : 'No upward movement this week',
+      tone: 'up',
+    },
+    {
+      label: 'Most Consistent',
+      playerId: consistency?.playerId ?? null,
+      value: playerName(players, consistency?.playerId ?? null),
+      detail: consistency ? 'Held the steadiest recent ranking arc' : 'Needs more weeks of data',
+      tone: 'steady',
+    },
+    {
+      label: 'Biggest Drop',
+      playerId: dropped?.playerId ?? null,
+      value: playerName(players, dropped?.playerId ?? null),
+      detail:
+        dropped && dropped.movement < 0
+          ? `Fell ${Math.abs(dropped.movement)} ${Math.abs(dropped.movement) === 1 ? 'spot' : 'spots'} this week`
+          : 'No downward movement this week',
+      tone: 'down',
+    },
+  ]
+}
+
+export function buildPublicState(
+  season: PublicState['season'],
+  weeks: Week[],
+  players: Player[],
+  rankings: WeekRanking[],
+  currentWeekId: string,
+  selectedWeekId: string,
+  revealCount: number,
+  updatedAt = new Date().toISOString(),
+): PublicState {
+  const selectedWeek = weeks.find((week) => week.id === selectedWeekId) ?? weeks.at(-1)
+  const selectedWeekNumber = selectedWeek?.weekNumber ?? 1
+  const hydratedRankings = rankings.map((ranking) => ({
+    ...ranking,
+    entries: orderEntries(ranking.entries).map((entry, index) => ({
+      ...entry,
+      revealed:
+        ranking.weekNumber < selectedWeekNumber ||
+        (ranking.weekNumber === selectedWeekNumber && index < revealCount) ||
+        entry.revealed,
+    })),
+  }))
+
+  return {
+    season,
+    weeks,
+    players,
+    rankings: hydratedRankings,
+    reveal: {
+      seasonId: season.id,
+      currentWeekId,
+      selectedWeekId,
+      revealCount,
+      updatedAt,
+    },
+    movements: calculateMovements(selectedWeekNumber, rankings, players),
+    stats: calculateStats(selectedWeekNumber, rankings, players),
+  }
+}
+
+export function orderEntries(entries: RankingEntry[]) {
+  return entries.slice().sort((a, b) => a.rank - b.rank)
+}

--- a/lib/reveal/types.ts
+++ b/lib/reveal/types.ts
@@ -1,0 +1,80 @@
+// Ported verbatim from big-brother-season-data-vis/src/types/domain.ts.
+// FROZEN: the original author owns these shapes. Do not redesign or rename.
+
+export type PlayerStatus = 'active' | 'eliminated'
+
+export type SeasonStatus = 'current' | 'previous'
+
+export type Player = {
+  id: string
+  seasonId: string
+  name: string
+  color: string
+  imageUrl: string
+  status: PlayerStatus
+  eliminatedWeek: number | null
+}
+
+export type Week = {
+  id: string
+  seasonId: string
+  weekNumber: number
+  status: SeasonStatus
+  title: string
+  isPublished: boolean
+}
+
+export type RankingEntry = {
+  playerId: string
+  rank: number
+  score: number
+  revealed: boolean
+}
+
+export type WeekRanking = {
+  weekId: string
+  weekNumber: number
+  entries: RankingEntry[]
+}
+
+export type RevealState = {
+  seasonId: string
+  currentWeekId: string
+  selectedWeekId: string
+  revealCount: number
+  updatedAt: string
+}
+
+export type PlayerMovement = {
+  playerId: string
+  rank: number
+  previousRank: number | null
+  movement: number
+  visualRank: number
+}
+
+export type StatCard = {
+  label: string
+  playerId: string | null
+  value: string
+  detail: string
+  tone: 'up' | 'steady' | 'down'
+}
+
+export type PublicState = {
+  season: {
+    id: string
+    number: number
+    status: SeasonStatus
+  }
+  weeks: Week[]
+  players: Player[]
+  rankings: WeekRanking[]
+  reveal: RevealState
+  movements: PlayerMovement[]
+  stats: StatCard[]
+}
+
+export type AdminState = PublicState & {
+  authenticated: true
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
@@ -28,6 +29,7 @@
     "@types/web-push": "^3.6.4",
     "serwist": "^9.5.11",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@20.19.41)(vite@8.0.14(@types/node@20.19.41)(jiti@2.7.0))
 
 packages:
 
@@ -95,8 +98,14 @@ packages:
       '@types/react':
         optional: true
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -282,6 +291,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.6':
     resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
@@ -337,6 +352,107 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@serwist/utils@9.5.11':
     resolution: {integrity: sha512-zqxmwuHqWA3OwN82Wo8gFZ9QBemygJP3cap5JWAOG4UyJZgUZfmBXAXj+IMaD4eKZ/6pqrxHHDZ9uSWZmJ1mXA==}
     peerDependencies:
@@ -344,6 +460,9 @@ packages:
     peerDependenciesMeta:
       browserslist:
         optional: true
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@supabase/auth-js@2.106.1':
     resolution: {integrity: sha512-7eyheXfAGwkB9bZewJPs+N3UYt6kra2JG6mIxNEgbkvcO15PLD1e75PTIUEYYl3zrifm3GrpShVl7QZxKrXO/w==}
@@ -472,6 +591,18 @@ packages:
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
 
@@ -486,12 +617,45 @@ packages:
   '@types/web-push@3.6.4':
     resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
 
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   baseline-browser-mapping@2.10.32:
     resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
@@ -507,8 +671,15 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -537,8 +708,32 @@ packages:
     resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
     engines: {node: '>=10.13.0'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   french-badwords-list@1.0.7:
     resolution: {integrity: sha512-H1ziKs2PJh2+UXZ9oCGJ/rRQpsI9NBykGf2Sc7WaKaj1OnWFuBXfsvANTdRcfVmOghGQaUmRyZ1hJOPbDpy04Q==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -687,8 +882,18 @@ packages:
       sass:
         optional: true
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -709,6 +914,11 @@ packages:
 
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   russian-bad-words@0.5.0:
     resolution: {integrity: sha512-euNvEYki6iYYpkNbeudW+lEMMYGEmN7EBwVF8ezlbv0bZoQpVYB7W10cCeUIGV7Ed50sJynLQ0c559q5iI0ejQ==}
@@ -740,9 +950,18 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -764,6 +983,21 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.3:
+    resolution: {integrity: sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -780,9 +1014,98 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  vite@8.0.14:
+    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-push@3.6.7:
     resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
     engines: {node: '>= 16'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
 snapshots:
@@ -814,7 +1137,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.15
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -952,6 +1286,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@next/env@16.2.6': {}
 
   '@next/swc-darwin-arm64@16.2.6':
@@ -978,7 +1319,62 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
+  '@oxc-project/types@0.132.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@serwist/utils@9.5.11': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.106.1':
     dependencies:
@@ -1090,6 +1486,20 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.0
 
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/node@20.19.41':
     dependencies:
       undici-types: 6.21.0
@@ -1106,6 +1516,47 @@ snapshots:
     dependencies:
       '@types/node': 20.19.41
 
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@20.19.41)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(@types/node@20.19.41)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   agent-base@7.1.4: {}
 
   asn1.js@5.4.1:
@@ -1115,6 +1566,8 @@ snapshots:
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
 
+  assertion-error@2.0.1: {}
+
   baseline-browser-mapping@2.10.32: {}
 
   bn.js@4.12.3: {}
@@ -1123,7 +1576,11 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  chai@6.2.2: {}
+
   client-only@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
 
@@ -1144,7 +1601,22 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  es-module-lexer@2.1.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   french-badwords-list@1.0.7:
+    optional: true
+
+  fsevents@2.3.3:
     optional: true
 
   graceful-fs@4.2.11: {}
@@ -1267,7 +1739,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  obug@2.1.1: {}
+
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
 
   postcss@8.4.31:
     dependencies:
@@ -1289,6 +1767,27 @@ snapshots:
   react@19.2.4: {}
 
   reselect@5.2.0: {}
+
+  rolldown@1.0.2:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.2
+      '@rolldown/binding-darwin-arm64': 1.0.2
+      '@rolldown/binding-darwin-x64': 1.0.2
+      '@rolldown/binding-freebsd-x64': 1.0.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
+      '@rolldown/binding-linux-arm64-gnu': 1.0.2
+      '@rolldown/binding-linux-arm64-musl': 1.0.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
+      '@rolldown/binding-linux-s390x-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-musl': 1.0.2
+      '@rolldown/binding-openharmony-arm64': 1.0.2
+      '@rolldown/binding-wasm32-wasi': 1.0.2
+      '@rolldown/binding-win32-arm64-msvc': 1.0.2
+      '@rolldown/binding-win32-x64-msvc': 1.0.2
 
   russian-bad-words@0.5.0:
     optional: true
@@ -1343,7 +1842,13 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:
@@ -1353,6 +1858,17 @@ snapshots:
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.3: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tslib@2.8.1: {}
 
@@ -1364,6 +1880,45 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  vite@8.0.14(@types/node@20.19.41)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.41
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
+  vitest@4.1.7(@types/node@20.19.41)(vite@8.0.14(@types/node@20.19.41)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@20.19.41)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.3
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@20.19.41)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.41
+    transitivePeerDependencies:
+      - msw
+
   web-push@3.6.7:
     dependencies:
       asn1.js: 5.4.1
@@ -1373,3 +1928,8 @@ snapshots:
       minimist: 1.2.8
     transitivePeerDependencies:
       - supports-color
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['lib/**/*.test.ts'],
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
Part of [#64](https://github.com/langermank/reality-stock-watch-app/issues/64) / [#61](https://github.com/langermank/reality-stock-watch-app/issues/61). The **pure-logic** half: the frozen ranking/reveal math (ported verbatim) plus the aggregation function. No DB, no UI.

## Frozen logic — ported behavior-preserving
`lib/reveal/rankings.ts` + `lib/reveal/types.ts` port the original `rankings.ts`/`domain.ts` verbatim (only import paths changed). The original author owns this logic; **parity tests lock our port to the original's exact outputs** — expected values were captured by running the original against its own `mockData.ts`.

## New
- `lib/reveal/aggregate.ts` — `aggregate(submissions, strategy?)` collapses many ranking submissions into one ordered list + per-contestant score. **Borda** is the default; **average-rank** provided as a swappable strategy.
- `lib/reveal/fixtures.ts` — original mock data as typed fixtures.
- Vitest set up (`vitest.config.ts`, `"test"` script).

## Status
- `pnpm test`: **19/19 passing** · `pnpm typecheck`: clean.

## Notes
- Deterministic Borda tie-break (secondary sort by `contestantId`) — the only behavioral choice not dictated by spec.
- `lib/reveal/types.ts` is the **canonical** domain types. The #65 chart PR has a parallel `components/reveal/` copy built in isolation; they reconcile to `lib/reveal` during #65b wiring.
- **Does not** include the data seam / seed fixtures (#64c) — that needs the schema (now applied) and lands next.

Part of #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)