### PR TITLE
feat: broadcast trajectory chart, presentational (#65a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ yarn-error.log*
 # vercel
 .vercel
 
+# local browser-automation / preview artifacts
+.playwright-cli/
+/output/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/app/(dev)/reveal-preview/page.tsx
+++ b/app/(dev)/reveal-preview/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+// TEMPORARY dev preview for issue #65a — verify the broadcast chart visually.
+//
+// This route exists ONLY to render BroadcastChart against in-memory fixtures so
+// it can be screenshotted in isolation. It does NOT fetch, gate, or auth.
+// Issue #65b builds the real admin-gated /stream route over Supabase Realtime
+// and this file should be deleted then.
+
+import { useMemo, useState } from "react";
+import { BroadcastChart } from "@/components/reveal/BroadcastChart";
+import { buildColorMap } from "@/components/reveal/colors";
+import { buildBroadcastState } from "@/components/reveal/rankings";
+import {
+  mockContestants,
+  mockRankings,
+  mockSeason,
+  mockSelectedWeekId,
+  mockWeeks,
+} from "@/components/reveal/mockData";
+
+const PRESETS: Array<{ label: string; revealCount: number }> = [
+  { label: "Mid-reveal (3 shown)", revealCount: 3 },
+  { label: "Just started (1 shown)", revealCount: 1 },
+  { label: "Fully revealed", revealCount: 99 },
+];
+
+export default function RevealPreviewPage() {
+  const [presetIndex, setPresetIndex] = useState(0);
+  const revealCount = PRESETS[presetIndex].revealCount;
+
+  const colorMap = useMemo(
+    () => buildColorMap(mockContestants.map((contestant) => contestant.id)),
+    [],
+  );
+  const colorOf = (id: string) => colorMap.get(id) ?? "#94a3b8";
+
+  const state = useMemo(
+    () =>
+      buildBroadcastState({
+        season: mockSeason,
+        weeks: mockWeeks,
+        contestants: mockContestants,
+        rankings: mockRankings,
+        selectedWeekId: mockSelectedWeekId,
+        revealCount,
+      }),
+    [revealCount],
+  );
+
+  return (
+    <div className="flex h-screen flex-col bg-black">
+      <div className="flex items-center gap-3 border-b border-white/10 bg-neutral-950 px-4 py-2 text-sm text-neutral-400">
+        <span className="font-mono text-xs uppercase tracking-widest text-amber-400">
+          TEMP PREVIEW · #65a
+        </span>
+        {PRESETS.map((preset, index) => (
+          <button
+            key={preset.label}
+            type="button"
+            onClick={() => setPresetIndex(index)}
+            className={`rounded px-3 py-1 font-semibold transition ${
+              index === presetIndex
+                ? "bg-sky-500 text-white"
+                : "bg-white/5 text-neutral-300 hover:bg-white/10"
+            }`}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+      {/* 16:9 broadcast canvas — what OBS would capture. */}
+      <div className="flex flex-1 items-center justify-center overflow-hidden p-4">
+        <div className="aspect-video h-full max-h-full w-full max-w-full overflow-hidden rounded-xl">
+          <BroadcastChart state={state} selectedWeekId={mockSelectedWeekId} colorOf={colorOf} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,3 +4,44 @@
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
+
+/* Broadcast trajectory chart animations (issue #65a, components/reveal).
+   Ported from the original data-vis repo's draw-line / pop-in keyframes. */
+@keyframes broadcast-draw-line {
+  from {
+    stroke-dashoffset: var(--path-length, 1400);
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes broadcast-pop-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.4);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.broadcast-line {
+  stroke-dasharray: var(--path-length, 1400);
+  animation: broadcast-draw-line 900ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.broadcast-dot {
+  animation: broadcast-pop-in 380ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .broadcast-line,
+  .broadcast-dot {
+    animation: none;
+    stroke-dasharray: none;
+  }
+}

--- a/components/reveal/BroadcastChart.tsx
+++ b/components/reveal/BroadcastChart.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+// Broadcast trajectory chart (issue #65a) — PURE presentational component.
+//
+// Ported from `big-brother-season-data-vis/src/components/StreamVisualization.tsx`.
+// The SVG geometry/logic is kept faithful; the styling is redesigned for
+// OBS/livestream capture (decision #8): near-black backdrop, oversized type,
+// thick strokes, large avatars — tuned to stay legible on a big screen and
+// survive stream-encoder compression.
+//
+// It fetches NOTHING. It receives a fully reveal-gated `BroadcastState` plus the
+// selected week and a contestant->color map. Issue #65b feeds it real data over
+// Supabase Realtime; this component is unchanged by that.
+
+import { useMemo, useState, type CSSProperties } from "react";
+import type { BroadcastState, WeekRanking } from "./types";
+import { calculateVisualRank, orderEntries } from "./rankings";
+
+type Props = {
+  state: BroadcastState;
+  selectedWeekId: string;
+  /** Stable color per contestant id (see colors.ts). */
+  colorOf: (contestantId: string) => string;
+};
+
+// SVG viewBox geometry — ported verbatim from the original. The chart scales to
+// its container via `viewBox`, so these are abstract units, not pixels.
+const chart = {
+  left: 150,
+  right: 230,
+  top: 56,
+  bottom: 72,
+  width: 1280,
+  height: 720,
+};
+
+function contestantById(state: BroadcastState, contestantId: string) {
+  return state.contestants.find((contestant) => contestant.id === contestantId);
+}
+
+function activeCount(ranking: WeekRanking) {
+  return Math.max(ranking.entries.length, 1);
+}
+
+function movementLabel(movement: number) {
+  if (movement > 0) return `▲${movement}`;
+  if (movement < 0) return `▼${Math.abs(movement)}`;
+  return "—";
+}
+
+function movementClass(movement: number) {
+  if (movement > 0) return "text-emerald-300";
+  if (movement < 0) return "text-rose-300";
+  return "text-slate-400";
+}
+
+function movementFill(movement: number) {
+  if (movement > 0) return "fill-emerald-300";
+  if (movement < 0) return "fill-rose-300";
+  return "fill-slate-500";
+}
+
+export function BroadcastChart({ state, selectedWeekId, colorOf }: Props) {
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  const selectedWeek =
+    state.weeks.find((week) => week.id === selectedWeekId) ?? state.weeks.at(-1);
+  const selectedRanking = state.rankings.find(
+    (ranking) => ranking.weekId === selectedWeek?.id,
+  );
+  const selectedEntries = orderEntries(selectedRanking?.entries ?? []);
+  const selectedWeekNumber = selectedWeek?.weekNumber ?? 1;
+  const movementByContestant = useMemo(
+    () => new Map(state.movements.map((movement) => [movement.contestantId, movement])),
+    [state.movements],
+  );
+
+  // X positions per week + Y per entry. Faithful port of the original geometry:
+  //   x = left + drawableWidth * weekIndex / max(weeks-1, 1)
+  //   y = top  + ((visualRank - 1) / 10) * drawableHeight
+  // visualRank maps a 1-based rank into a 1..11 band so weeks with different
+  // roster sizes line up vertically.
+  const geometry = useMemo(() => {
+    const drawableWidth = chart.width - chart.left - chart.right;
+    const drawableHeight = chart.height - chart.top - chart.bottom;
+    const weekSpan = Math.max(state.weeks.length - 1, 1);
+
+    return state.rankings.map((ranking, weekIndex) => {
+      const x = chart.left + (drawableWidth * weekIndex) / weekSpan;
+      return {
+        ...ranking,
+        x,
+        points: ranking.entries.map((entry) => ({
+          ...entry,
+          weekNumber: ranking.weekNumber,
+          x,
+          y:
+            chart.top +
+            ((calculateVisualRank(entry.rank, activeCount(ranking)) - 1) / 10) * drawableHeight,
+        })),
+      };
+    });
+  }, [state.rankings, state.weeks.length]);
+
+  const gridBands = ["Top", "Upper", "Median", "Lower", "Bottom"];
+
+  return (
+    <div className="grid h-full w-full grid-cols-[minmax(300px,0.26fr)_1fr] gap-5 bg-[#05060b] p-6 text-slate-100">
+      {/* Leaderboard sidebar — the selected (live) week's ranking, gated. */}
+      <aside className="flex min-h-0 flex-col rounded-2xl border border-white/10 bg-gradient-to-b from-white/[0.06] to-transparent p-5 shadow-2xl">
+        <div className="mb-5 flex items-end justify-between">
+          <div>
+            <p className="text-sm font-bold uppercase tracking-[0.3em] text-slate-500">
+              Season {state.season.number}
+            </p>
+            <h1 className="text-4xl font-black leading-none tracking-tight text-white">
+              Fan Rankings
+            </h1>
+          </div>
+          <span className="rounded-lg bg-sky-500 px-3 py-1.5 text-lg font-black text-white shadow-lg shadow-sky-500/30">
+            WK {selectedWeekNumber}
+          </span>
+        </div>
+
+        <div className="min-h-0 flex-1 space-y-2 overflow-hidden">
+          {selectedEntries.map((entry) => {
+            const contestant = contestantById(state, entry.contestantId);
+            const movement = movementByContestant.get(entry.contestantId)?.movement ?? 0;
+            const isRevealed = entry.revealed;
+            const color = colorOf(entry.contestantId);
+            const isDimmed = isRevealed && hovered !== null && hovered !== entry.contestantId;
+
+            return (
+              <div
+                key={entry.contestantId}
+                role={isRevealed ? "button" : undefined}
+                onMouseEnter={() => isRevealed && setHovered(entry.contestantId)}
+                onMouseLeave={() => isRevealed && setHovered(null)}
+                className={`grid grid-cols-[48px_56px_1fr_auto] items-center gap-3 rounded-xl border p-2.5 transition-opacity ${
+                  isRevealed
+                    ? "border-white/10 bg-white/[0.04]"
+                    : "border-dashed border-white/[0.08] bg-white/[0.015]"
+                } ${isDimmed ? "opacity-40" : "opacity-100"}`}
+              >
+                <span
+                  className={`grid h-11 w-11 place-items-center rounded-xl text-2xl font-black tabular-nums ${
+                    isRevealed && entry.rank <= 3
+                      ? "text-[#05060b]"
+                      : isRevealed
+                        ? "bg-white/5 text-slate-200"
+                        : "bg-white/[0.03] text-slate-600"
+                  }`}
+                  style={
+                    isRevealed && entry.rank <= 3
+                      ? { backgroundColor: color, boxShadow: `0 0 24px ${color}66` }
+                      : undefined
+                  }
+                >
+                  {entry.rank}
+                </span>
+                <span
+                  className="grid h-12 w-12 place-items-center overflow-hidden rounded-full border-[3px]"
+                  style={{
+                    borderColor: isRevealed ? color : "rgba(255,255,255,0.08)",
+                    background: "#0b0d16",
+                  }}
+                >
+                  {isRevealed && contestant?.photoUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      className="h-full w-full object-cover"
+                      src={contestant.photoUrl}
+                      alt=""
+                    />
+                  ) : null}
+                </span>
+                <span className="truncate text-2xl font-black tracking-tight text-white">
+                  {isRevealed ? contestant?.name : "• • •"}
+                </span>
+                {isRevealed ? (
+                  <span className={`text-xl font-black tabular-nums ${movementClass(movement)}`}>
+                    {movementLabel(movement)}
+                  </span>
+                ) : (
+                  <span />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </aside>
+
+      {/* Main column: trajectory chart + stat cards. */}
+      <main className="grid min-w-0 grid-rows-[1fr_150px] gap-5">
+        <section className="relative min-h-0 overflow-hidden rounded-2xl border border-white/10 bg-[#0a0c14] shadow-2xl">
+          {/* Subtle vignette for broadcast depth. */}
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_100%_at_50%_0%,rgba(56,189,248,0.07),transparent_60%)]" />
+          <svg
+            className="relative h-full w-full"
+            viewBox={`0 0 ${chart.width} ${chart.height}`}
+            role="img"
+            preserveAspectRatio="xMidYMid meet"
+          >
+            <title>Week-by-week fan ranking trajectory</title>
+
+            {/* Horizontal grid bands. */}
+            {gridBands.map((label, index) => {
+              const y = chart.top + ((chart.height - chart.top - chart.bottom) * index) / 4;
+              const edge = index === 0 || index === gridBands.length - 1;
+              return (
+                <g key={label}>
+                  <line
+                    x1={chart.left}
+                    x2={chart.width - chart.right}
+                    y1={y}
+                    y2={y}
+                    stroke={edge ? "#2a3550" : "#1a2236"}
+                    strokeWidth={edge ? 2 : 1}
+                    strokeDasharray={edge ? "0" : "4 10"}
+                  />
+                  <text
+                    x={chart.left - 18}
+                    y={y + 7}
+                    textAnchor="end"
+                    className="fill-slate-500 text-[20px] font-black uppercase tracking-wider"
+                  >
+                    {label}
+                  </text>
+                </g>
+              );
+            })}
+
+            {/* Week verticals + axis labels. */}
+            {geometry.map((week) => (
+              <g key={week.weekId}>
+                <line
+                  x1={week.x}
+                  x2={week.x}
+                  y1={chart.top}
+                  y2={chart.height - chart.bottom}
+                  stroke={week.weekNumber === selectedWeekNumber ? "#38bdf8" : "#1a2236"}
+                  strokeWidth={week.weekNumber === selectedWeekNumber ? 2.5 : 1}
+                  strokeDasharray="3 9"
+                />
+                <text
+                  x={week.x}
+                  y={chart.height - 26}
+                  textAnchor="middle"
+                  className={`text-[22px] font-black ${
+                    week.weekNumber === selectedWeekNumber ? "fill-sky-300" : "fill-slate-500"
+                  }`}
+                >
+                  WK {week.weekNumber}
+                </text>
+              </g>
+            ))}
+
+            {/* One trajectory line per contestant. Only REVEALED points are
+                drawn; an unrevealed live-week point hides that segment. A line
+                also simply ends when the contestant stops appearing (eviction
+                by presence). */}
+            {state.contestants.map((contestant) => {
+              const points = geometry
+                .map((week) => week.points.find((point) => point.contestantId === contestant.id))
+                .filter((point): point is NonNullable<typeof point> => Boolean(point?.revealed));
+              if (points.length === 0) return null;
+
+              const color = colorOf(contestant.id);
+              const path = points
+                .map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`)
+                .join(" ");
+              const isHovered = hovered === contestant.id;
+              const active = hovered === null || isHovered;
+
+              return (
+                <g key={contestant.id} opacity={active ? 1 : 0.14}>
+                  {/* Soft glow underlay for broadcast pop. */}
+                  <path
+                    d={path}
+                    fill="none"
+                    stroke={color}
+                    strokeWidth={isHovered ? 14 : 9}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    opacity={0.22}
+                  />
+                  <path
+                    d={path}
+                    fill="none"
+                    stroke={color}
+                    strokeWidth={isHovered ? 7 : 4.5}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="broadcast-line"
+                    style={{ "--path-length": 1400 } as CSSProperties}
+                  />
+                  {points.map((point) => (
+                    <circle
+                      key={`${contestant.id}-${point.weekNumber}`}
+                      cx={point.x}
+                      cy={point.y}
+                      r={isHovered ? 11 : 8}
+                      fill={color}
+                      stroke="#05060b"
+                      strokeWidth={4}
+                      className="broadcast-dot"
+                    />
+                  ))}
+                </g>
+              );
+            })}
+
+            {/* End-of-line name labels for the selected week's revealed entries. */}
+            {selectedEntries.map((entry) => {
+              const contestant = contestantById(state, entry.contestantId);
+              const point = geometry
+                .find((week) => week.weekNumber === selectedWeekNumber)
+                ?.points.find((candidate) => candidate.contestantId === entry.contestantId);
+              const movement = movementByContestant.get(entry.contestantId)?.movement ?? 0;
+
+              if (!contestant || !point || !entry.revealed) return null;
+              const dim = hovered !== null && hovered !== contestant.id;
+
+              return (
+                <g key={`label-${entry.contestantId}`} opacity={dim ? 0.2 : 1}>
+                  <text
+                    x={chart.width - chart.right + 22}
+                    y={point.y - 6}
+                    className="fill-white text-[26px] font-black"
+                  >
+                    {contestant.name}
+                  </text>
+                  <text
+                    x={chart.width - chart.right + 22}
+                    y={point.y + 22}
+                    className={`text-[20px] font-black ${movementFill(movement)}`}
+                  >
+                    #{entry.rank} {movementLabel(movement)}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        </section>
+
+        {/* Stat cards. */}
+        <section className="grid grid-cols-3 gap-5">
+          {state.stats.map((stat) => (
+            <article
+              key={stat.label}
+              className="flex flex-col justify-center rounded-2xl border border-white/10 bg-white/[0.04] p-5 text-center shadow-xl"
+            >
+              <p className="text-sm font-black uppercase tracking-[0.25em] text-slate-500">
+                {stat.label}
+              </p>
+              <h2
+                className={`mt-1 truncate text-4xl font-black tracking-tight ${
+                  stat.tone === "up"
+                    ? "text-emerald-300"
+                    : stat.tone === "down"
+                      ? "text-rose-300"
+                      : "text-sky-300"
+                }`}
+              >
+                {stat.value}
+              </h2>
+              <p className="mt-1.5 text-lg font-semibold text-slate-400">{stat.detail}</p>
+            </article>
+          ))}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/components/reveal/colors.ts
+++ b/components/reveal/colors.ts
@@ -1,0 +1,79 @@
+// Deterministic per-contestant color palette (issue #65a).
+//
+// Our `contestants` table has no `color` column (the original data-vis repo
+// did). We derive a stable, vivid color from the contestant id so the same
+// contestant always draws in the same color across renders and reloads —
+// critical for a broadcast where viewers track lines week to week.
+//
+// Tuned for OBS/livestream capture against a near-black backdrop: saturated,
+// high-luminance hues that stay distinct when compressed by a stream encoder.
+
+const BROADCAST_PALETTE = [
+  "#ff4d6d", // rose
+  "#4dd4ff", // cyan
+  "#ffd24d", // amber
+  "#7c5cff", // violet
+  "#3ddc84", // green
+  "#ff8a3d", // orange
+  "#ff5ce8", // magenta
+  "#36e0c8", // teal
+  "#a0ff4d", // lime
+  "#5c8bff", // blue
+  "#ff6f4d", // coral
+  "#c77dff", // lavender
+  "#ffe14d", // yellow
+  "#4dffb0", // mint
+  "#ff4da6", // pink
+  "#6de2ff", // sky
+] as const;
+
+/**
+ * FNV-1a-style string hash. Stable across runtime/platform, unlike a naive
+ * char-sum (which collides badly on anagram-like ids). We only need a
+ * well-distributed integer to index the palette.
+ */
+function hashId(id: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < id.length; i += 1) {
+    hash ^= id.charCodeAt(i);
+    // 32-bit FNV prime multiply, kept in unsigned range.
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+/** Stable broadcast color for a contestant id. */
+export function contestantColor(id: string): string {
+  return BROADCAST_PALETTE[hashId(id) % BROADCAST_PALETTE.length];
+}
+
+/**
+ * Assign colors across a roster while minimizing adjacent-index collisions.
+ *
+ * A pure `hash % length` can map two contestants to the same swatch. For a
+ * legible chart we want every drawn line distinct, so we hash-seed the order
+ * but then hand out unique palette slots greedily, falling back to the raw
+ * hash color only once the palette is exhausted (more contestants than colors).
+ */
+export function buildColorMap(ids: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  const used = new Set<number>();
+
+  // Sort by hash so assignment is deterministic regardless of input order.
+  const ordered = [...ids].sort((a, b) => hashId(a) - hashId(b));
+
+  for (const id of ordered) {
+    const preferred = hashId(id) % BROADCAST_PALETTE.length;
+    let slot = preferred;
+    if (used.size < BROADCAST_PALETTE.length) {
+      // Walk forward to the next free slot for a collision-free assignment.
+      while (used.has(slot)) {
+        slot = (slot + 1) % BROADCAST_PALETTE.length;
+      }
+      used.add(slot);
+    }
+    map.set(id, BROADCAST_PALETTE[slot]);
+  }
+
+  return map;
+}

--- a/components/reveal/mockData.ts
+++ b/components/reveal/mockData.ts
@@ -1,0 +1,86 @@
+// In-memory fixtures so the broadcast chart runs in isolation (issue #65a).
+//
+// Ported from `big-brother-season-data-vis/src/lib/mockData.ts`, reshaped to
+// Reality Stock Watch types. Differences from the source fixtures:
+//   - No `color` column — colors are derived from id at render (see colors.ts).
+//   - No `eliminatedWeek` — eviction is by PRESENCE (a contestant drops out of
+//     later weekly orders). e.g. `kelley` is absent from week 7's order, so the
+//     chart line simply ends after week 6.
+//   - `imageUrl` -> `photoUrl`, populated with deterministic avatar URLs so the
+//     sidebar shows photos without any backend.
+//
+// #65b replaces this entirely with seeded `survey_aggregate_rankings` over the
+// data seam; the component never knows the difference.
+
+import type { Contestant, Week, WeekRanking } from "./types";
+
+export const mockSeason = {
+  id: "season-30",
+  number: 30,
+};
+
+const ROSTER: Array<[id: string, name: string]> = [
+  ["rachel", "Rachel"],
+  ["ashley", "Ashley"],
+  ["will", "Will"],
+  ["morgan", "Morgan"],
+  ["ava", "Ava"],
+  ["vince", "Vince"],
+  ["lauren", "Lauren"],
+  ["katherine", "Katherine"],
+  ["mickey", "Mickey"],
+  ["keanu", "Keanu"],
+  ["kelley", "Kelley"],
+  ["joey", "Joey"],
+  ["jessica", "Jessica"],
+];
+
+export const mockContestants: Contestant[] = ROSTER.map(([id, name]) => ({
+  id,
+  seasonId: mockSeason.id,
+  name,
+  // Deterministic placeholder avatar so the chart has photos in isolation.
+  photoUrl: `https://i.pravatar.cc/96?u=${id}`,
+  status: "active",
+}));
+
+const TOTAL_WEEKS = 7;
+/** The live week being revealed on stream. */
+export const mockSelectedWeekId = `week-${TOTAL_WEEKS}`;
+/** How many of the live week's entries the producer has revealed so far. */
+export const mockRevealCount = 3;
+
+export const mockWeeks: Week[] = Array.from({ length: TOTAL_WEEKS }, (_, index) => {
+  const weekNumber = index + 1;
+  return {
+    id: `week-${weekNumber}`,
+    seasonId: mockSeason.id,
+    weekNumber,
+    title: `Week ${weekNumber}`,
+  };
+});
+
+// Top-first ordering per week. A contestant absent from a week's order is
+// treated as evicted from that week onward (presence-based eviction).
+const weeklyOrders: string[][] = [
+  ["rachel", "morgan", "lauren", "mickey", "ashley", "katherine", "will", "joey", "jessica", "ava", "vince", "keanu", "kelley"],
+  ["ava", "rachel", "mickey", "morgan", "will", "joey", "katherine", "jessica", "ashley", "lauren", "vince", "kelley", "keanu"],
+  ["ava", "rachel", "mickey", "morgan", "will", "joey", "ashley", "jessica", "katherine", "lauren", "vince", "kelley"],
+  ["ava", "rachel", "ashley", "will", "lauren", "jessica", "katherine", "vince", "keanu", "morgan", "mickey", "kelley"],
+  ["rachel", "ava", "ashley", "will", "lauren", "morgan", "jessica", "vince", "keanu", "mickey", "kelley"],
+  ["rachel", "ava", "will", "katherine", "lauren", "keanu", "vince", "ashley", "morgan", "mickey", "kelley"],
+  ["rachel", "ashley", "will", "morgan", "ava", "vince", "lauren", "katherine", "mickey", "keanu"],
+];
+
+export const mockRankings: WeekRanking[] = weeklyOrders.map((order, index) => ({
+  weekId: `week-${index + 1}`,
+  weekNumber: index + 1,
+  entries: order.map((contestantId, orderIndex) => ({
+    contestantId,
+    rank: orderIndex + 1,
+    // Borda-flavored score (higher = better) with mild weekly drift for spread.
+    score: Math.round((100 - orderIndex * 5.7 + index * 1.3) * 10) / 10,
+    // Raw fixture reveal flag; reveal gating is applied by buildBroadcastState.
+    revealed: index + 1 < TOTAL_WEEKS,
+  })),
+}));

--- a/components/reveal/rankings.ts
+++ b/components/reveal/rankings.ts
@@ -1,0 +1,223 @@
+// Ranking + reveal math for the broadcast chart (issue #65a).
+//
+// Ported from `big-brother-season-data-vis/src/lib/rankings.ts`, behavior-
+// preserving, with two adaptations for Reality Stock Watch:
+//   1. `playerId` -> `contestantId` throughout.
+//   2. Eviction is derived from PRESENCE, not an `eliminatedWeek` column. A
+//      contestant who appears in week N-1 but not week N is treated as removed
+//      between those weeks. This replaces the original's `eliminatedWeek`
+//      checks in `calculateMovement` / `getActiveContestantsForWeek`.
+//
+// NOTE: This is a local, presentational port so the component runs in isolation.
+// The frozen canonical port lives in `lib/reveal/rankings.ts` (issue #65b) and
+// is locked with parity tests there; this copy is reconciled at integration.
+
+import type {
+  Contestant,
+  ContestantMovement,
+  RankingEntry,
+  StatCard,
+  Week,
+  WeekRanking,
+} from "./types";
+
+export function entriesForWeek(rankings: WeekRanking[], weekNumber: number) {
+  return rankings.find((ranking) => ranking.weekNumber === weekNumber)?.entries ?? [];
+}
+
+export function orderEntries(entries: RankingEntry[]) {
+  return entries.slice().sort((a, b) => a.rank - b.rank);
+}
+
+/**
+ * Apply reveal gating for a single week. Entries are ordered top-first and the
+ * first `revealCount` become visible (in addition to anything pre-revealed).
+ * Mirrors the original `visibleEntriesForWeek`.
+ */
+export function visibleEntriesForWeek(
+  rankings: WeekRanking[],
+  weekNumber: number,
+  revealCount: number,
+) {
+  return orderEntries(entriesForWeek(rankings, weekNumber)).map((entry, index) => ({
+    ...entry,
+    revealed: index < revealCount || entry.revealed,
+  }));
+}
+
+/**
+ * Map a 1-based rank to a 1..11 visual band so weeks with different roster
+ * sizes line up vertically. Unchanged from the original.
+ */
+export function calculateVisualRank(rank: number, activeCount: number) {
+  if (activeCount <= 1) {
+    return 1;
+  }
+  return 1 + ((rank - 1) / (activeCount - 1)) * 10;
+}
+
+/**
+ * Net rank change vs. the previous week, corrected for contestants removed
+ * (evicted) from above.
+ *
+ * Original logic counted "removed above" using `eliminatedWeek === weekNumber`.
+ * We instead derive removal from presence: a contestant ranked above the
+ * subject last week who is absent from this week's ranking. This keeps the
+ * movement number honest (you don't get credited for rising past someone who
+ * was simply evicted).
+ */
+export function calculateMovement(
+  contestantId: string,
+  weekNumber: number,
+  rankings: WeekRanking[],
+) {
+  const currentEntries = entriesForWeek(rankings, weekNumber);
+  const previousEntries = entriesForWeek(rankings, weekNumber - 1);
+  const current = currentEntries.find((entry) => entry.contestantId === contestantId);
+  const previous = previousEntries.find((entry) => entry.contestantId === contestantId);
+
+  if (!current || !previous) {
+    return 0;
+  }
+
+  const currentIds = new Set(currentEntries.map((entry) => entry.contestantId));
+  const removedAbove = previousEntries.filter(
+    (entry) => entry.rank < previous.rank && !currentIds.has(entry.contestantId),
+  ).length;
+
+  const expectedRank = previous.rank - removedAbove;
+  return expectedRank - current.rank;
+}
+
+export function calculateMovements(
+  selectedWeekNumber: number,
+  rankings: WeekRanking[],
+): ContestantMovement[] {
+  const entries = orderEntries(entriesForWeek(rankings, selectedWeekNumber));
+  const previousEntries = entriesForWeek(rankings, selectedWeekNumber - 1);
+  const activeCount = Math.max(entries.length, 1);
+
+  return entries.map((entry) => ({
+    contestantId: entry.contestantId,
+    rank: entry.rank,
+    previousRank:
+      previousEntries.find((previous) => previous.contestantId === entry.contestantId)?.rank ??
+      null,
+    movement: calculateMovement(entry.contestantId, selectedWeekNumber, rankings),
+    visualRank: calculateVisualRank(entry.rank, activeCount),
+  }));
+}
+
+function contestantName(contestants: Contestant[], contestantId: string | null) {
+  return contestants.find((contestant) => contestant.id === contestantId)?.name ?? "No data";
+}
+
+export function calculateStats(
+  selectedWeekNumber: number,
+  rankings: WeekRanking[],
+  contestants: Contestant[],
+): StatCard[] {
+  const movements = calculateMovements(selectedWeekNumber, rankings);
+  const improved = movements.reduce<ContestantMovement | null>(
+    (best, movement) => (best === null || movement.movement > best.movement ? movement : best),
+    null,
+  );
+  const dropped = movements.reduce<ContestantMovement | null>(
+    (worst, movement) => (worst === null || movement.movement < worst.movement ? movement : worst),
+    null,
+  );
+
+  const recentWeeks = rankings
+    .filter((ranking) => ranking.weekNumber <= selectedWeekNumber)
+    .slice(-4);
+
+  const consistency = contestants
+    .map((contestant) => {
+      const ranks = recentWeeks
+        .map((ranking) => ranking.entries.find((entry) => entry.contestantId === contestant.id)?.rank)
+        .filter((rank): rank is number => typeof rank === "number");
+
+      if (ranks.length < 2) {
+        return null;
+      }
+
+      const average = ranks.reduce((sum, rank) => sum + rank, 0) / ranks.length;
+      const variance =
+        ranks.reduce((sum, rank) => sum + Math.abs(rank - average), 0) / ranks.length;
+      return { contestantId: contestant.id, variance, bestRank: Math.min(...ranks) };
+    })
+    .filter(
+      (entry): entry is { contestantId: string; variance: number; bestRank: number } =>
+        entry !== null,
+    )
+    .sort((a, b) => a.variance - b.variance || a.bestRank - b.bestRank)[0];
+
+  return [
+    {
+      label: "Most Improved",
+      contestantId: improved?.contestantId ?? null,
+      value: contestantName(contestants, improved?.contestantId ?? null),
+      detail:
+        improved && improved.movement > 0
+          ? `Rose ${improved.movement} ${improved.movement === 1 ? "spot" : "spots"} this week`
+          : "No upward movement this week",
+      tone: "up",
+    },
+    {
+      label: "Most Consistent",
+      contestantId: consistency?.contestantId ?? null,
+      value: contestantName(contestants, consistency?.contestantId ?? null),
+      detail: consistency ? "Held the steadiest recent ranking arc" : "Needs more weeks of data",
+      tone: "steady",
+    },
+    {
+      label: "Biggest Drop",
+      contestantId: dropped?.contestantId ?? null,
+      value: contestantName(contestants, dropped?.contestantId ?? null),
+      detail:
+        dropped && dropped.movement < 0
+          ? `Fell ${Math.abs(dropped.movement)} ${Math.abs(dropped.movement) === 1 ? "spot" : "spots"} this week`
+          : "No downward movement this week",
+      tone: "down",
+    },
+  ];
+}
+
+/**
+ * Apply reveal gating across all weeks and compute movements + stats for the
+ * selected week. Mirrors the original `buildPublicState`: prior weeks are fully
+ * revealed, the selected week is gated by `revealCount` (top-first), later
+ * weeks stay hidden.
+ */
+export function buildBroadcastState(args: {
+  season: { id: string; number: number };
+  weeks: Week[];
+  contestants: Contestant[];
+  rankings: WeekRanking[];
+  selectedWeekId: string;
+  revealCount: number;
+}) {
+  const { season, weeks, contestants, rankings, selectedWeekId, revealCount } = args;
+  const selectedWeek = weeks.find((week) => week.id === selectedWeekId) ?? weeks.at(-1);
+  const selectedWeekNumber = selectedWeek?.weekNumber ?? 1;
+
+  const hydratedRankings = rankings.map((ranking) => ({
+    ...ranking,
+    entries: orderEntries(ranking.entries).map((entry, index) => ({
+      ...entry,
+      revealed:
+        ranking.weekNumber < selectedWeekNumber ||
+        (ranking.weekNumber === selectedWeekNumber && index < revealCount) ||
+        entry.revealed,
+    })),
+  }));
+
+  return {
+    season,
+    weeks,
+    contestants,
+    rankings: hydratedRankings,
+    movements: calculateMovements(selectedWeekNumber, rankings),
+    stats: calculateStats(selectedWeekNumber, rankings, contestants),
+  };
+}

--- a/components/reveal/types.ts
+++ b/components/reveal/types.ts
@@ -1,0 +1,82 @@
+// Presentational types for the broadcast trajectory chart (issue #65a).
+//
+// These are LOCAL to the chart component so it runs in isolation against mock
+// data. They intentionally do NOT live in `lib/reveal/` — a parallel agent owns
+// that path (issue #65b). Some duplication is expected; it gets reconciled at
+// integration. The shapes mirror the original `big-brother-season-data-vis`
+// domain types, adapted to Reality Stock Watch:
+//   - `Player.color`          -> derived from id (no color column here)
+//   - `Player.imageUrl`       -> `Contestant.photoUrl` (our `photo_url`)
+//   - `Player.eliminatedWeek` -> dropped; eviction is derived from presence
+
+export type ContestantStatus = "active" | "evicted" | "jury" | "winner";
+
+/** A tradeable contestant, mirroring our `contestants` row (camelCased subset). */
+export type Contestant = {
+  id: string;
+  seasonId: string;
+  name: string;
+  /** Maps to `contestants.photo_url`; may be null when no photo exists. */
+  photoUrl: string | null;
+  status: ContestantStatus;
+};
+
+/** One contestant's standing within a single week's ranking. */
+export type RankingEntry = {
+  contestantId: string;
+  /** 1 = top of the ranking. */
+  rank: number;
+  /** Y-axis magnitude (Borda points or avg-rank score). Higher = better. */
+  score: number;
+  /**
+   * Whether this entry has been revealed on stream. For prior (closed) weeks
+   * this is always true. For the live week it is gated by `revealCount`.
+   * The chart NEVER draws an unrevealed entry.
+   */
+  revealed: boolean;
+};
+
+/** Aggregate ranking for a single week / survey. */
+export type WeekRanking = {
+  weekId: string;
+  weekNumber: number;
+  entries: RankingEntry[];
+};
+
+export type Week = {
+  id: string;
+  seasonId: string;
+  weekNumber: number;
+  title: string;
+};
+
+/** Per-contestant movement vs. the previous week. */
+export type ContestantMovement = {
+  contestantId: string;
+  rank: number;
+  previousRank: number | null;
+  movement: number;
+  visualRank: number;
+};
+
+export type StatCard = {
+  label: string;
+  contestantId: string | null;
+  value: string;
+  detail: string;
+  tone: "up" | "steady" | "down";
+};
+
+/**
+ * Everything the chart needs to render, with reveal gating already applied.
+ * Mirrors the original `PublicState` so #65b can feed it real data over
+ * Realtime without reshaping the component.
+ */
+export type BroadcastState = {
+  season: { id: string; number: number };
+  weeks: Week[];
+  contestants: Contestant[];
+  rankings: WeekRanking[];
+  movements: ContestantMovement[];
+  stats: StatCard[];
+};


### PR DESCRIPTION
Part of [#65](https://github.com/langermank/reality-stock-watch-app/issues/65) / [#61](https://github.com/langermank/reality-stock-watch-app/issues/61). The **pure/visual** half: a self-contained broadcast chart built against mock data. No data fetching, no Supabase, no Realtime, no auth — that's #65b.

## What's here
- `components/reveal/BroadcastChart.tsx` — custom **SVG** trajectory chart (no charting lib), props-only. Ports the original's geometry, **restyled for OBS/livestream capture** (near-black canvas, oversized type, thick glowing strokes).
- `components/reveal/colors.ts` — deterministic per-contestant color palette (FNV-1a hash → 16-color palette; no `color` column exists). `buildColorMap` avoids collisions across the drawn roster.
- `components/reveal/rankings.ts` + `types.ts` — local presentational copy of the reveal math (reconciles to canonical `lib/reveal` in #65b).
- `components/reveal/mockData.ts` — ported fixtures.
- `app/(dev)/reveal-preview/page.tsx` — **TEMPORARY** preview route (mid-reveal / just-started / fully-revealed toggles). Deleted in #65b.
- `app/globals.css` — added `broadcast-line`/`broadcast-dot` keyframes.

## Adaptations
- **Eviction by presence** — no `eliminatedWeek` column, so a line ends when a contestant stops appearing in the weekly rankings.
- **Spoiler-safe** — unrevealed current-week points truncate the line rather than drawing early (verified in screenshots).

## Status
- `pnpm typecheck`: clean. Verified visually via screenshots (mid-reveal / just-started / fully-revealed).
- Dropped the original's hover week-tooltip (a broadcast capture is non-interactive).

Part of #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)