### PR TITLE
chore: bump db-push workflow actions to Node 24 + pin versions

### DIFF
--- a/.github/workflows/db-push.yml
+++ b/.github/workflows/db-push.yml
@@ -36,11 +36,11 @@ jobs:
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DB_PASSWORD }}
       PROD_PROJECT_REF: avakcpjthtrmeswgjlxz # rsw-production (not secret — already in docs/migrations.md)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: supabase/setup-cli@v1
+      - uses: supabase/setup-cli@v2.1.1
         with:
-          version: latest
+          version: 2.102.0
 
       - name: Link production project
         run: supabase link --project-ref "$PROD_PROJECT_REF"


### PR DESCRIPTION
Follow-up to #70. Clears the Node 20 deprecation warning on the prod migration workflow and pins versions so CI behavior doesn't drift.

## Changes (`.github/workflows/db-push.yml`)
- `actions/checkout@v4` → `@v6` (Node 24 runtime)
- `supabase/setup-cli@v1` → `@v2.1.1` (Node 24 runtime, pinned to a specific tag)
- Supabase CLI `version: latest` → `version: 2.102.0` (pinned)

## Verify after merge
The workflow is unchanged in behavior — just newer runners. Once merged, re-run the manual dry-run to confirm the bumped actions still authenticate:
Actions → *Deploy DB migrations (production)* → *Run workflow* → dry run = true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)