### PR TITLE
feat: survey page with 5 states + anonymous public link (#41)

### DIFF
--- a/app/(app)/survey/page.tsx
+++ b/app/(app)/survey/page.tsx
@@ -1,8 +1,20 @@
-export default function SurveyPage() {
-  return (
-    <div className="p-4">
-      <h1 className="text-xl font-semibold">Survey</h1>
-      <p className="mt-2 text-neutral-400 text-sm">No active survey right now — check back soon.</p>
-    </div>
-  );
+// Logged-in survey page (issue #41). State-driven single route.
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getSurveyPageState } from "@/lib/survey/source";
+import { SurveyView } from "@/components/survey/SurveyView";
+
+// Survey + response state changes frequently; never statically cache.
+export const dynamic = "force-dynamic";
+
+export default async function SurveyPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const state = await getSurveyPageState(user.id);
+  return <SurveyView state={state} />;
 }

--- a/app/survey/[id]/public/layout.tsx
+++ b/app/survey/[id]/public/layout.tsx
@@ -1,0 +1,13 @@
+// Standalone layout for the anonymous public survey link (issue #41).
+//
+// Lives OUTSIDE the (app) group so the global nav/header/trade overlay don't
+// render here. Anonymous users are intentionally not "app users" — the
+// experience is a single page with no path back into the rest of the app.
+
+export default function PublicSurveyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <div className="min-h-dvh bg-neutral-950 text-neutral-100">{children}</div>;
+}

--- a/app/survey/[id]/public/page.tsx
+++ b/app/survey/[id]/public/page.tsx
@@ -1,0 +1,47 @@
+// Anonymous public survey route (issue #41).
+//
+// Standalone — no auth required, no app nav (the layout above this is the
+// chrome-less shell). When the survey is active we render the form against
+// the service-role-backed anonymous submit path. Any other status surfaces
+// a single "this survey is closed" sentence; the closed/results states are
+// intentionally NOT exposed to anonymous users (decision in design doc).
+
+import { getPublicSurvey } from "@/lib/survey/source";
+import { PublicSurveyClient } from "@/components/survey/PublicSurveyClient";
+
+export const dynamic = "force-dynamic";
+
+type Params = { id: string };
+
+export default async function PublicSurveyPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { id } = await params;
+  const state = await getPublicSurvey(id);
+
+  if (!state) {
+    return (
+      <main className="mx-auto flex min-h-dvh max-w-md flex-col justify-center p-6 text-center">
+        <h1 className="text-2xl font-black tracking-tight">Survey not found</h1>
+        <p className="mt-3 text-sm text-neutral-400">
+          The link may be incorrect.
+        </p>
+      </main>
+    );
+  }
+
+  if (state.kind === "closed") {
+    return (
+      <main className="mx-auto flex min-h-dvh max-w-md flex-col justify-center p-6 text-center">
+        <h1 className="text-2xl font-black tracking-tight">This survey is closed</h1>
+        <p className="mt-3 text-sm text-neutral-400">
+          Thanks for your interest. Check back next week.
+        </p>
+      </main>
+    );
+  }
+
+  return <PublicSurveyClient survey={state.survey} questions={state.questions} />;
+}

--- a/components/survey/Choice.tsx
+++ b/components/survey/Choice.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+// Single- and multi-choice inputs (issue #41).
+//
+// Two thin wrappers over native inputs (Base UI's Radio/Checkbox add markup
+// these inputs don't need yet). Both maintain controlled state; the parent
+// owns answers.
+
+type SingleProps = {
+  name: string;
+  options: readonly string[];
+  value: string | null;
+  onChange: (next: string) => void;
+};
+
+export function SingleChoice({ name, options, value, onChange }: SingleProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      {options.map((option) => {
+        const selected = option === value;
+        return (
+          <label
+            key={option}
+            className={`flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition ${
+              selected
+                ? "border-sky-400 bg-sky-500/10"
+                : "border-white/10 bg-white/[0.02] hover:border-white/20"
+            }`}
+          >
+            <input
+              type="radio"
+              name={name}
+              value={option}
+              checked={selected}
+              onChange={() => onChange(option)}
+              className="h-4 w-4 accent-sky-400"
+            />
+            <span className="text-sm font-medium text-neutral-100">{option}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+type MultiProps = {
+  name: string;
+  options: readonly string[];
+  value: string[];
+  onChange: (next: string[]) => void;
+};
+
+export function MultipleChoice({ name, options, value, onChange }: MultiProps) {
+  const set = new Set(value);
+  return (
+    <div className="flex flex-col gap-2">
+      {options.map((option) => {
+        const selected = set.has(option);
+        return (
+          <label
+            key={option}
+            className={`flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition ${
+              selected
+                ? "border-sky-400 bg-sky-500/10"
+                : "border-white/10 bg-white/[0.02] hover:border-white/20"
+            }`}
+          >
+            <input
+              type="checkbox"
+              name={name}
+              value={option}
+              checked={selected}
+              onChange={() => {
+                const next = new Set(set);
+                if (next.has(option)) next.delete(option);
+                else next.add(option);
+                // Preserve original option order so the answer is stable across renders.
+                onChange(options.filter((o) => next.has(o)));
+              }}
+              className="h-4 w-4 accent-sky-400"
+            />
+            <span className="text-sm font-medium text-neutral-100">{option}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/survey/PublicSurveyClient.tsx
+++ b/components/survey/PublicSurveyClient.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+// Client wrapper for the anonymous public survey route.
+//
+// Lives separately from /survey's SurveyView because the surrounding chrome
+// is fundamentally different: no app nav, a post-submit confirmation that
+// pitches account creation rather than a "your picks" inline view, and a
+// closed-state that's just a single sentence with no path back into the app
+// (decision in interaction-flow-survey.md).
+
+import { useState } from "react";
+import Link from "next/link";
+import { SurveyForm } from "./SurveyForm";
+import { submitAnonymousResponse } from "@/lib/survey/actions";
+import type { SurveyMeta, SurveyQuestion } from "@/lib/survey/source";
+
+type Props = {
+  survey: SurveyMeta;
+  questions: SurveyQuestion[];
+};
+
+export function PublicSurveyClient({ survey, questions }: Props) {
+  const [submitted, setSubmitted] = useState(false);
+
+  if (submitted) {
+    return (
+      <main className="mx-auto flex min-h-dvh max-w-md flex-col justify-center p-6 text-center">
+        <h1 className="text-2xl font-black tracking-tight">Response submitted</h1>
+        <p className="mt-3 text-sm text-neutral-400">
+          Thanks for taking the survey.
+        </p>
+        <div className="mt-8 rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+          <p className="text-sm font-semibold text-neutral-100">
+            Want to see the results?
+          </p>
+          <p className="mt-1 text-xs text-neutral-400">
+            Create an account to view how others voted once results are
+            published, and follow the next survey live.
+          </p>
+          <Link
+            href="/login"
+            className="mt-4 inline-block rounded-xl bg-sky-500 px-4 py-2 text-sm font-bold text-white shadow-lg shadow-sky-500/30 hover:bg-sky-400"
+          >
+            Create an account
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <header className="mb-6">
+        <p className="text-xs font-bold uppercase tracking-[0.25em] text-neutral-500">
+          Week {survey.weekNumber}
+        </p>
+        <h1 className="mt-1 text-2xl font-black tracking-tight">{survey.title}</h1>
+      </header>
+      <SurveyForm
+        surveyId={survey.id}
+        questions={questions}
+        submit={submitAnonymousResponse}
+        submitLabel="Submit response"
+        onSubmitted={() => setSubmitted(true)}
+      />
+    </main>
+  );
+}

--- a/components/survey/PushPrompt.tsx
+++ b/components/survey/PushPrompt.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+// Inline push-notification permission prompt for the survey page (issue #41).
+//
+// Hidden states (so the surface never nags):
+//   - The browser doesn't support Notification or PushManager
+//   - Permission already granted (subscription exists or is being created)
+//   - Permission already denied — we can't re-prompt without OS-level fixes,
+//     and a "you said no" reminder is hostile
+//
+// On click: ask the browser, subscribe via PushManager, POST the subscription
+// to /api/push/subscribe (auth required — survey page is already gated).
+
+import { useEffect, useState } from "react";
+
+function urlBase64ToArrayBuffer(base64: string): ArrayBuffer {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const value = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(value);
+  const buffer = new ArrayBuffer(raw.length);
+  const arr = new Uint8Array(buffer);
+  for (let i = 0; i < raw.length; i += 1) arr[i] = raw.charCodeAt(i);
+  return buffer;
+}
+
+type Status = "hidden" | "prompt" | "subscribing" | "subscribed" | "error";
+
+export function PushPrompt() {
+  const [status, setStatus] = useState<Status>("hidden");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (typeof window === "undefined") return;
+      if (!("Notification" in window) || !("serviceWorker" in navigator) || !("PushManager" in window)) return;
+      if (Notification.permission === "denied") return;
+      if (Notification.permission === "granted") {
+        // Already permitted; check for an existing subscription so we don't
+        // surface a button that does nothing.
+        try {
+          const reg = await navigator.serviceWorker.getRegistration();
+          const existing = await reg?.pushManager.getSubscription();
+          if (existing) return; // truly subscribed → leave hidden
+        } catch {
+          /* fall through to prompt — best-effort */
+        }
+      }
+      if (!cancelled) setStatus("prompt");
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (status === "hidden") return null;
+
+  if (status === "subscribed") {
+    return (
+      <p className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-200">
+        Notifications enabled — we&apos;ll ping you when results land.
+      </p>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <p className="rounded-lg border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-200">
+        Couldn&apos;t enable notifications. You can try again later from your browser settings.
+      </p>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={status === "subscribing"}
+      onClick={async () => {
+        setStatus("subscribing");
+        try {
+          const permission = await Notification.requestPermission();
+          if (permission !== "granted") {
+            setStatus("hidden");
+            return;
+          }
+          // The PWA service worker registration is owned by the app shell.
+          // Wait for it to be ready rather than re-registering here.
+          const reg = await navigator.serviceWorker.ready;
+          const vapid = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+          if (!vapid) {
+            setStatus("error");
+            return;
+          }
+          const subscription = await reg.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToArrayBuffer(vapid),
+          });
+          const json = subscription.toJSON();
+          const response = await fetch("/api/push/subscribe", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              endpoint: json.endpoint,
+              keys: json.keys,
+            }),
+          });
+          if (!response.ok) {
+            setStatus("error");
+            return;
+          }
+          setStatus("subscribed");
+        } catch {
+          setStatus("error");
+        }
+      }}
+      className="flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm font-semibold text-neutral-100 transition hover:bg-white/[0.08] disabled:opacity-50"
+    >
+      🔔{" "}
+      {status === "subscribing"
+        ? "Enabling notifications…"
+        : "Notify me when results are posted"}
+    </button>
+  );
+}

--- a/components/survey/Ranking.tsx
+++ b/components/survey/Ranking.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+// Drag-to-reorder ranking input (issue #41).
+//
+// HTML5 native DnD — no external library. Each row is draggable; dragover on
+// another row swaps positions in the controlled `value` array. Touch users
+// get the up/down buttons as a fallback path (touch HTML5 DnD is unreliable).
+//
+// `value` is an array of option strings in submitted-rank order (best first).
+// On change we hand the parent the same shape.
+
+import { useState } from "react";
+
+type Props = {
+  options: readonly string[];
+  value: string[];
+  onChange: (next: string[]) => void;
+  /** id for label association — questions share names across the form */
+  id?: string;
+};
+
+function move<T>(arr: T[], from: number, to: number): T[] {
+  if (from === to || from < 0 || to < 0 || from >= arr.length || to >= arr.length) return arr;
+  const next = arr.slice();
+  const [item] = next.splice(from, 1);
+  next.splice(to, 0, item);
+  return next;
+}
+
+export function Ranking({ options, value, onChange, id }: Props) {
+  // Initialize ranks from `value`; fall back to option order. Stay in sync if
+  // upstream `value` ever resets (e.g. after submit).
+  const ordered = value.length === options.length ? value : [...options];
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+
+  return (
+    <ol
+      id={id}
+      className="flex flex-col gap-2"
+      aria-label="Drag to reorder, top is best"
+    >
+      {ordered.map((option, index) => (
+        <li
+          key={option}
+          draggable
+          onDragStart={(event) => {
+            setDraggingIndex(index);
+            event.dataTransfer.effectAllowed = "move";
+            // Firefox needs data on the drag event to actually fire dragover.
+            event.dataTransfer.setData("text/plain", String(index));
+          }}
+          onDragOver={(event) => {
+            event.preventDefault();
+            if (draggingIndex === null || draggingIndex === index) return;
+            onChange(move(ordered, draggingIndex, index));
+            setDraggingIndex(index);
+          }}
+          onDragEnd={() => setDraggingIndex(null)}
+          className={`group flex items-center gap-3 rounded-lg border bg-white/[0.02] p-3 transition ${
+            draggingIndex === index
+              ? "border-sky-400 bg-sky-500/10"
+              : "border-white/10 hover:border-white/20"
+          }`}
+        >
+          <span
+            aria-hidden="true"
+            className="grid h-7 w-7 shrink-0 place-items-center rounded text-xs font-bold text-neutral-400"
+          >
+            {index + 1}
+          </span>
+          <span className="flex-1 text-sm font-medium text-neutral-100">{option}</span>
+          {/* Touch / no-DnD fallback. Hidden on hover devices to keep the row clean. */}
+          <span className="flex gap-1">
+            <button
+              type="button"
+              aria-label={`Move ${option} up`}
+              onClick={() => onChange(move(ordered, index, index - 1))}
+              disabled={index === 0}
+              className="grid h-7 w-7 place-items-center rounded text-neutral-400 hover:bg-white/10 disabled:opacity-30"
+            >
+              ▲
+            </button>
+            <button
+              type="button"
+              aria-label={`Move ${option} down`}
+              onClick={() => onChange(move(ordered, index, index + 1))}
+              disabled={index === ordered.length - 1}
+              className="grid h-7 w-7 place-items-center rounded text-neutral-400 hover:bg-white/10 disabled:opacity-30"
+            >
+              ▼
+            </button>
+            <span
+              aria-hidden="true"
+              className="grid h-7 w-7 place-items-center text-neutral-500 cursor-grab active:cursor-grabbing"
+              title="Drag"
+            >
+              ⋮⋮
+            </span>
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/components/survey/SurveyForm.tsx
+++ b/components/survey/SurveyForm.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+// Survey form (issue #41).
+//
+// Renders all questions for a survey, owns the in-progress answers, runs a
+// minimal "are we done" gate, and posts to the parent-supplied submit action.
+// Used by both /survey (logged-in) and /survey/[id]/public (anonymous) — the
+// submit action differs but the form is identical.
+
+import { useState, useTransition } from "react";
+import { Ranking } from "./Ranking";
+import { SingleChoice, MultipleChoice } from "./Choice";
+import type { SurveyQuestion } from "@/lib/survey/source";
+import type { AnswerValue, SubmitResult } from "@/lib/survey/actions";
+
+type Props = {
+  surveyId: string;
+  questions: SurveyQuestion[];
+  submit: (
+    surveyId: string,
+    answers: Record<string, AnswerValue>,
+  ) => Promise<SubmitResult>;
+  onSubmitted?: () => void;
+  submitLabel?: string;
+};
+
+/** Build an empty answer per question, sized correctly for ranking. */
+function initialAnswers(questions: SurveyQuestion[]): Record<string, AnswerValue> {
+  const result: Record<string, AnswerValue> = {};
+  for (const question of questions) {
+    if (question.type === "ranking") result[question.id] = [...question.options];
+    else if (question.type === "multiple_choice") result[question.id] = [];
+    else result[question.id] = "";
+  }
+  return result;
+}
+
+function isAnswered(question: SurveyQuestion, value: AnswerValue): boolean {
+  if (question.type === "ranking") {
+    return Array.isArray(value) && value.length === question.options.length;
+  }
+  if (question.type === "multiple_choice") {
+    return Array.isArray(value) && value.length > 0;
+  }
+  return typeof value === "string" && value.length > 0;
+}
+
+export function SurveyForm({
+  surveyId,
+  questions,
+  submit,
+  onSubmitted,
+  submitLabel = "Submit",
+}: Props) {
+  const [answers, setAnswers] = useState<Record<string, AnswerValue>>(() =>
+    initialAnswers(questions),
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const allAnswered = questions.every((question) => isAnswered(question, answers[question.id]));
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        setError(null);
+        startTransition(async () => {
+          const result = await submit(surveyId, answers);
+          if (result.ok) {
+            onSubmitted?.();
+            return;
+          }
+          setError(
+            result.error === "already-submitted"
+              ? "You've already submitted this survey."
+              : result.error === "not-active"
+                ? "This survey isn't open for submissions."
+                : "Something went wrong. Try again?",
+          );
+        });
+      }}
+      className="flex flex-col gap-6"
+    >
+      {questions.map((question) => (
+        <fieldset key={question.id} className="flex flex-col gap-3">
+          <legend className="text-base font-semibold text-neutral-100">
+            {question.text}
+          </legend>
+          {question.type === "ranking" ? (
+            <Ranking
+              id={`q-${question.id}`}
+              options={question.options}
+              value={(answers[question.id] as string[] | undefined) ?? []}
+              onChange={(next) =>
+                setAnswers((prev) => ({ ...prev, [question.id]: next }))
+              }
+            />
+          ) : question.type === "multiple_choice" ? (
+            <MultipleChoice
+              name={`q-${question.id}`}
+              options={question.options}
+              value={(answers[question.id] as string[] | undefined) ?? []}
+              onChange={(next) =>
+                setAnswers((prev) => ({ ...prev, [question.id]: next }))
+              }
+            />
+          ) : (
+            <SingleChoice
+              name={`q-${question.id}`}
+              options={question.options}
+              value={(answers[question.id] as string | undefined) ?? null}
+              onChange={(next) =>
+                setAnswers((prev) => ({ ...prev, [question.id]: next }))
+              }
+            />
+          )}
+        </fieldset>
+      ))}
+
+      {error && (
+        <p className="rounded-lg border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-200">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isPending || !allAnswered}
+        className="rounded-xl bg-sky-500 px-4 py-3 text-base font-bold text-white shadow-lg shadow-sky-500/30 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-neutral-700 disabled:text-neutral-400 disabled:shadow-none"
+      >
+        {isPending ? "Submitting…" : submitLabel}
+      </button>
+    </form>
+  );
+}

--- a/components/survey/SurveyView.tsx
+++ b/components/survey/SurveyView.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+// State switcher for the logged-in survey page (issue #41).
+//
+// Receives the discriminated `SurveyPageState` from the server and renders
+// the right surface for each of the five states. Form submission flips
+// active-not-submitted -> active-submitted via a local optimistic flag, and
+// router.refresh re-reads the server state so subsequent renders use the
+// real DB row.
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { SurveyForm } from "./SurveyForm";
+import { YourPicks } from "./YourPicks";
+import { PushPrompt } from "./PushPrompt";
+import { submitResponse } from "@/lib/survey/actions";
+import type { SurveyMeta, SurveyPageState, SurveyQuestion } from "@/lib/survey/source";
+
+function SurveyHeader({ title, weekNumber }: { title: string; weekNumber: number }) {
+  return (
+    <header className="mb-6">
+      <p className="text-xs font-bold uppercase tracking-[0.25em] text-neutral-500">
+        Week {weekNumber}
+      </p>
+      <h1 className="mt-1 text-2xl font-black tracking-tight text-neutral-100">{title}</h1>
+    </header>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return <div className="mx-auto max-w-2xl p-6">{children}</div>;
+}
+
+function ThanksBanner() {
+  return (
+    <div className="mb-6 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-5">
+      <p className="text-base font-semibold text-emerald-200">
+        Thanks for your response!
+      </p>
+      <p className="mt-1 text-sm text-emerald-100/80">
+        Results will be posted after the survey closes.
+      </p>
+    </div>
+  );
+}
+
+/** Render for the active-submitted state (also reused as the optimistic
+ *  "just submitted" view after a successful form post). */
+function SubmittedView({
+  survey,
+  questions,
+  answers,
+}: {
+  survey: SurveyMeta;
+  questions: SurveyQuestion[];
+  answers: Record<string, unknown> | null;
+}) {
+  return (
+    <Card>
+      <SurveyHeader title={survey.title} weekNumber={survey.weekNumber} />
+      <ThanksBanner />
+      {answers && Object.keys(answers).length > 0 && (
+        <YourPicks questions={questions} answers={answers} />
+      )}
+    </Card>
+  );
+}
+
+export function SurveyView({ state }: { state: SurveyPageState }) {
+  const router = useRouter();
+  // Optimistic flip: after submit succeeds we render SubmittedView
+  // immediately while router.refresh re-reads the DB in the background.
+  const [optimisticAnswers, setOptimisticAnswers] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
+
+  if (state.kind === "no-active") {
+    return (
+      <Card>
+        <h1 className="text-2xl font-black tracking-tight text-neutral-100">Survey</h1>
+        <p className="mt-3 text-sm text-neutral-400">
+          No survey right now — check back soon.
+        </p>
+      </Card>
+    );
+  }
+
+  if (state.kind === "active-not-submitted") {
+    if (optimisticAnswers) {
+      return (
+        <SubmittedView
+          survey={state.survey}
+          questions={state.questions}
+          answers={optimisticAnswers}
+        />
+      );
+    }
+    return (
+      <Card>
+        <SurveyHeader title={state.survey.title} weekNumber={state.survey.weekNumber} />
+        <SurveyForm
+          surveyId={state.survey.id}
+          questions={state.questions}
+          submit={async (surveyId, answers) => {
+            const result = await submitResponse(surveyId, answers);
+            if (result.ok) {
+              setOptimisticAnswers(answers);
+              router.refresh();
+            }
+            return result;
+          }}
+          submitLabel="Submit response"
+        />
+        <div className="mt-8">
+          <PushPrompt />
+        </div>
+      </Card>
+    );
+  }
+
+  if (state.kind === "active-submitted") {
+    return (
+      <SubmittedView
+        survey={state.survey}
+        questions={state.questions}
+        answers={state.answers}
+      />
+    );
+  }
+
+  if (state.kind === "closed-pending") {
+    return (
+      <Card>
+        <SurveyHeader title={state.survey.title} weekNumber={state.survey.weekNumber} />
+        <div className="mb-6 rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+          <p className="text-base font-semibold text-neutral-100">Survey closed.</p>
+          <p className="mt-1 text-sm text-neutral-400">
+            Check back soon for results.
+          </p>
+        </div>
+        {state.answers && (
+          <YourPicks questions={state.questions} answers={state.answers} />
+        )}
+      </Card>
+    );
+  }
+
+  // results-published
+  return (
+    <Card>
+      <SurveyHeader title={state.survey.title} weekNumber={state.survey.weekNumber} />
+      <div className="mb-6 rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+        <p className="text-sm font-bold uppercase tracking-widest text-neutral-500">
+          Results
+        </p>
+        <p className="mt-2 text-sm text-neutral-400">
+          A full results chart is coming soon. Until then, your submitted picks
+          are below.
+        </p>
+      </div>
+      {state.answers && (
+        <YourPicks questions={state.questions} answers={state.answers} />
+      )}
+    </Card>
+  );
+}

--- a/components/survey/YourPicks.tsx
+++ b/components/survey/YourPicks.tsx
@@ -1,0 +1,71 @@
+// Read-only render of the user's submitted answers ("Your picks" / "Your
+// response"). Shown across the submitted, closed-pending, and
+// results-published states.
+
+import type { SurveyQuestion } from "@/lib/survey/source";
+
+type Props = {
+  questions: SurveyQuestion[];
+  answers: Record<string, unknown>;
+  title?: string;
+};
+
+function formatAnswer(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value === "string") return [value];
+  return ["(no answer)"];
+}
+
+export function YourPicks({ questions, answers, title = "Your picks" }: Props) {
+  // If we don't have questions (e.g. closed survey we can't read), render only
+  // the answer keys/values opaquely so the user still sees what they sent.
+  if (questions.length === 0) {
+    return (
+      <section className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
+        <h2 className="mb-3 text-sm font-bold uppercase tracking-widest text-neutral-400">
+          {title}
+        </h2>
+        <ul className="flex flex-col gap-3">
+          {Object.entries(answers).map(([key, value]) => (
+            <li key={key} className="text-sm">
+              <p className="text-neutral-300">{formatAnswer(value).join(" · ")}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
+      <h2 className="mb-3 text-sm font-bold uppercase tracking-widest text-neutral-400">
+        {title}
+      </h2>
+      <dl className="flex flex-col gap-4">
+        {questions.map((question) => {
+          const lines = formatAnswer(answers[question.id]);
+          return (
+            <div key={question.id}>
+              <dt className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                {question.text}
+              </dt>
+              <dd className="mt-1 text-sm text-neutral-100">
+                {question.type === "ranking" ? (
+                  <ol className="list-inside list-decimal space-y-0.5">
+                    {lines.map((line, i) => (
+                      <li key={i} className="tabular-nums">
+                        {line}
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <p>{lines.join(", ")}</p>
+                )}
+              </dd>
+            </div>
+          );
+        })}
+      </dl>
+    </section>
+  );
+}

--- a/lib/survey/actions.ts
+++ b/lib/survey/actions.ts
@@ -1,0 +1,91 @@
+"use server";
+
+// Survey submission (issue #41).
+//
+// Two paths:
+//   - submitResponse: logged-in user. Goes through the user-scoped server
+//     client; RLS enforces auth.uid() = user_id and the per-user unique index
+//     prevents double-submit.
+//   - submitAnonymousResponse: public-link user. Uses the service-role client
+//     (server-only) because there is no RLS INSERT policy for the anon role,
+//     and we validate the survey is `active` ourselves. user_id stays null
+//     and is_anonymous = true.
+//
+// Both write the `answers` jsonb as { [questionId]: answer } where answer is
+// a string (single_choice), string[] (multiple_choice), or string[] (ranking,
+// best-first). Names are stored — matching the seed and the design doc.
+
+import { createClient } from "@/lib/supabase/server";
+import { serviceClient } from "@/lib/supabase/service";
+
+export type AnswerValue = string | string[];
+
+export type SubmitResult =
+  | { ok: true }
+  | { ok: false; error: "no-survey" | "not-active" | "already-submitted" | "unknown" };
+
+export async function submitResponse(
+  surveyId: string,
+  answers: Record<string, AnswerValue>,
+): Promise<SubmitResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: "unknown" };
+
+  // Confirm survey is active before writing. RLS already gates this read, but
+  // the explicit check turns a silent insert-then-no-op into a clean error.
+  const { data: surveyRow } = await supabase
+    .from("surveys")
+    .select("status")
+    .eq("id", surveyId)
+    .maybeSingle();
+  const survey = surveyRow as { status: string } | null;
+  if (!survey) return { ok: false, error: "no-survey" };
+  if (survey.status !== "active") return { ok: false, error: "not-active" };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase.from("survey_responses") as any).insert({
+    survey_id: surveyId,
+    user_id: user.id,
+    answers,
+    is_anonymous: false,
+  });
+  if (error) {
+    // 23505 = unique_violation (per-user unique index).
+    if ("code" in error && (error as { code: string }).code === "23505") {
+      return { ok: false, error: "already-submitted" };
+    }
+    return { ok: false, error: "unknown" };
+  }
+  return { ok: true };
+}
+
+export async function submitAnonymousResponse(
+  surveyId: string,
+  answers: Record<string, AnswerValue>,
+): Promise<SubmitResult> {
+  // Validate the survey is active. Use the service client so this works even
+  // before any auth check, but we still gate the WRITE on status === 'active'
+  // here in code (anon users can't see closed/draft surveys).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: row } = await (serviceClient as any)
+    .from("surveys")
+    .select("status")
+    .eq("id", surveyId)
+    .maybeSingle();
+  const survey = row as { status: string } | null;
+  if (!survey) return { ok: false, error: "no-survey" };
+  if (survey.status !== "active") return { ok: false, error: "not-active" };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (serviceClient.from("survey_responses") as any).insert({
+    survey_id: surveyId,
+    user_id: null,
+    answers,
+    is_anonymous: true,
+  });
+  if (error) return { ok: false, error: "unknown" };
+  return { ok: true };
+}

--- a/lib/survey/source.ts
+++ b/lib/survey/source.ts
@@ -1,0 +1,243 @@
+// Survey data loaders (issue #41).
+//
+// The user-facing survey page is single-route, multi-state. This module
+// reduces the active season's surveys + the user's response to a discriminated
+// union the page can switch on. Question options for `uses_contestants=true`
+// are resolved at READ TIME against the season's active contestants — that
+// way the form always reflects the current cast (a contestant evicted between
+// survey-open and the user's load is simply absent).
+
+import { createClient } from "@/lib/supabase/server";
+
+export type QuestionType = "ranking" | "multiple_choice" | "single_choice";
+
+export type SurveyQuestion = {
+  id: string;
+  text: string;
+  type: QuestionType;
+  displayOrder: number;
+  /** Resolved options ready for the form. For uses_contestants=true these
+   *  are contestant names from the active roster; otherwise the column's
+   *  static options[]. May be empty (e.g. text-only question — not used yet). */
+  options: string[];
+  usesContestants: boolean;
+};
+
+export type SurveyMeta = {
+  id: string;
+  title: string;
+  weekNumber: number;
+  status: "draft" | "active" | "closed" | "results_published";
+  closesAt: string | null;
+};
+
+/** Discriminated union mirroring the 5 states in docs/design/interaction-flow-survey.md. */
+export type SurveyPageState =
+  | { kind: "no-active" }
+  | { kind: "active-not-submitted"; survey: SurveyMeta; questions: SurveyQuestion[] }
+  | {
+      kind: "active-submitted";
+      survey: SurveyMeta;
+      questions: SurveyQuestion[];
+      answers: Record<string, unknown>;
+    }
+  | {
+      kind: "closed-pending";
+      survey: SurveyMeta;
+      questions: SurveyQuestion[];
+      answers: Record<string, unknown> | null;
+    }
+  | {
+      kind: "results-published";
+      survey: SurveyMeta;
+      questions: SurveyQuestion[];
+      answers: Record<string, unknown> | null;
+    };
+
+type SurveyRow = {
+  id: string;
+  title: string;
+  week_number: number;
+  status: SurveyMeta["status"];
+  closes_at: string | null;
+};
+type QuestionRow = {
+  id: string;
+  text: string;
+  type: QuestionType;
+  display_order: number;
+  options: string[] | null;
+  uses_contestants: boolean;
+};
+
+/**
+ * Pick the survey to show on /survey: prefer active, else the most recent
+ * closed-but-not-yet-published, else the most recent published. Returns null
+ * if the active season has no surveys at all.
+ */
+async function pickRelevantSurvey(seasonId: string): Promise<SurveyRow | null> {
+  const supabase = await createClient();
+  const fields = "id, title, week_number, status, closes_at";
+
+  // 1. Active (one at most — enforced by partial unique index).
+  const { data: activeRow } = await supabase
+    .from("surveys")
+    .select(fields)
+    .eq("season_id", seasonId)
+    .eq("status", "active")
+    .maybeSingle();
+  if (activeRow) return activeRow as SurveyRow;
+
+  // 2. Most recent closed (results pending publication).
+  const { data: closedRows } = await supabase
+    .from("surveys")
+    .select(fields)
+    .eq("season_id", seasonId)
+    .eq("status", "closed")
+    .order("week_number", { ascending: false })
+    .limit(1);
+  const closed = (closedRows as SurveyRow[] | null)?.[0];
+  if (closed) return closed;
+
+  // 3. Most recent results-published. (The "no active" state intentionally
+  //    does NOT surface old results — see design doc decision.)
+  const { data: publishedRows } = await supabase
+    .from("surveys")
+    .select(fields)
+    .eq("season_id", seasonId)
+    .eq("status", "results_published")
+    .order("week_number", { ascending: false })
+    .limit(1);
+  return ((publishedRows as SurveyRow[] | null)?.[0]) ?? null;
+}
+
+async function loadActiveContestantNames(seasonId: string): Promise<string[]> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("contestants")
+    .select("name, status")
+    .eq("season_id", seasonId)
+    .eq("status", "active")
+    .order("name");
+  return ((data as { name: string }[] | null) ?? []).map((row) => row.name);
+}
+
+/** Compute the survey page state for a given user + active season. */
+export async function getSurveyPageState(userId: string): Promise<SurveyPageState> {
+  const supabase = await createClient();
+
+  const { data: seasonRow } = await supabase
+    .from("seasons")
+    .select("id")
+    .eq("status", "active")
+    .maybeSingle();
+  const season = seasonRow as { id: string } | null;
+  if (!season) return { kind: "no-active" };
+
+  const survey = await pickRelevantSurvey(season.id);
+  if (!survey) return { kind: "no-active" };
+
+  // Status determines which state we're in. For active and results_published
+  // the RLS policy lets us read questions; for closed/draft we still need
+  // them if we already submitted (to render Your Picks), so admin-mode would
+  // bypass — but the closed-state user IS the one who submitted, so they
+  // already have the answers, and questions are accessible because... actually
+  // closed/draft don't satisfy the RLS read policy. Workaround: only fetch
+  // questions when status is active or results_published. For closed-pending
+  // we render from `answers` alone, treating it as opaque key/value.
+  let questions: SurveyQuestion[] = [];
+  if (survey.status === "active" || survey.status === "results_published") {
+    questions = await loadQuestions(survey.id, season.id);
+  }
+
+  // Did this user submit?
+  const { data: responseRow } = await supabase
+    .from("survey_responses")
+    .select("answers")
+    .eq("survey_id", survey.id)
+    .eq("user_id", userId)
+    .maybeSingle();
+  const answers = (responseRow as { answers: Record<string, unknown> } | null)?.answers ?? null;
+
+  const meta: SurveyMeta = {
+    id: survey.id,
+    title: survey.title,
+    weekNumber: survey.week_number,
+    status: survey.status,
+    closesAt: survey.closes_at,
+  };
+
+  if (survey.status === "active") {
+    return answers
+      ? { kind: "active-submitted", survey: meta, questions, answers }
+      : { kind: "active-not-submitted", survey: meta, questions };
+  }
+  if (survey.status === "closed") {
+    return { kind: "closed-pending", survey: meta, questions, answers };
+  }
+  if (survey.status === "results_published") {
+    return { kind: "results-published", survey: meta, questions, answers };
+  }
+  return { kind: "no-active" }; // draft — treat as none
+}
+
+/** Load + resolve questions for the survey (used by both logged-in & public routes). */
+export async function loadQuestions(
+  surveyId: string,
+  seasonId: string,
+): Promise<SurveyQuestion[]> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("survey_questions")
+    .select("id, text, type, display_order, options, uses_contestants")
+    .eq("survey_id", surveyId)
+    .order("display_order");
+  const rows = (data as QuestionRow[] | null) ?? [];
+  if (rows.length === 0) return [];
+
+  // Resolve contestant lists once if any question needs them.
+  const needsContestants = rows.some((row) => row.uses_contestants);
+  const contestants = needsContestants ? await loadActiveContestantNames(seasonId) : [];
+
+  return rows.map((row) => ({
+    id: row.id,
+    text: row.text,
+    type: row.type,
+    displayOrder: row.display_order,
+    options: row.uses_contestants ? contestants : (row.options ?? []),
+    usesContestants: row.uses_contestants,
+  }));
+}
+
+/** Public-link loader: the survey, its questions, and a closed/active flag.
+ *  Surfaces the "closed/published" state separately so the public route can
+ *  show "this survey is closed" without exposing user-only views. */
+export async function getPublicSurvey(surveyId: string): Promise<
+  | { kind: "active"; survey: SurveyMeta; questions: SurveyQuestion[] }
+  | { kind: "closed"; survey: SurveyMeta }
+  | null
+> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("surveys")
+    .select("id, title, week_number, status, closes_at, season_id")
+    .eq("id", surveyId)
+    .maybeSingle();
+  const row = data as (SurveyRow & { season_id: string }) | null;
+  if (!row) return null;
+
+  const meta: SurveyMeta = {
+    id: row.id,
+    title: row.title,
+    weekNumber: row.week_number,
+    status: row.status,
+    closesAt: row.closes_at,
+  };
+
+  if (row.status === "active") {
+    const questions = await loadQuestions(row.id, row.season_id);
+    return { kind: "active", survey: meta, questions };
+  }
+  // closed / results_published / draft → all "closed" from anon perspective
+  return { kind: "closed", survey: meta };
+}


### PR DESCRIPTION
Closes most of Phase 3. Logged-in users can view + submit the active survey through a single state-driven route; anonymous users can submit through `/survey/[id]/public`.

## What's in
- **`lib/survey/source.ts`** — `getSurveyPageState(userId)` reduces the active season's surveys + the user's response into a discriminated union over the 5 design-doc states. Question options for `uses_contestants=true` are resolved at read time against the current active roster.
- **`lib/survey/actions.ts`** — `submitResponse` (logged-in, RLS-gated) and `submitAnonymousResponse` (service-role server action, validates `status='active'` itself since there's no RLS INSERT policy for the anon role).
- **`components/survey/Ranking.tsx`** — HTML5 native drag-to-reorder with up/down/grip fallback (no dnd lib).
- **`components/survey/Choice.tsx`** — `SingleChoice` (radio) + `MultipleChoice` (checkbox).
- **`components/survey/SurveyForm.tsx`** — orchestrates the three question types; reused by both routes.
- **`components/survey/SurveyView.tsx`** — the logged-in 5-state switch + optimistic flip on submit (`router.refresh()` re-reads the server view).
- **`components/survey/PushPrompt.tsx`** — inline notification permission prompt; hidden when unsupported / already-granted / denied.
- **`app/(app)/survey/page.tsx`** — server shell, replaces the one-line stub.
- **`app/survey/[id]/public/{page,layout}.tsx`** — anonymous route OUTSIDE the `(app)` group so global nav/chrome don't render. Closed/draft/published surveys all surface a single "This survey is closed" sentence to anonymous users (decision in design doc).

## Verified end-to-end (logged in as admin, against local Supabase)
- ✅ **State 1 — no-active**: all surveys flipped to `draft` → "No survey right now — check back soon."
- ✅ **State 2 — active-not-submitted**: WK 3 with all 9 active contestants (Enzo correctly absent), ranking + single-choice question, submit disabled until both answered.
- ✅ **State 3 — active-submitted** (the live flip after I clicked Submit): "Thanks for your response!" banner + "Your picks" with both questions resolved. DB row inserted with `is_anonymous=false`, correct user, the chosen answers (verified raw JSON in the DB).
- ✅ **State 4 — closed-pending**: "Survey closed. Check back soon for results." + opaque answer list (RLS hides question text for closed surveys; the YourPicks component falls back to a plain answer list).
- ✅ **State 5 — results-published**: "Results / A full results chart is coming soon." + Your picks with full question text (RLS allows reads on `results_published`).
- ✅ **Anonymous /survey/[id]/public (active)**: same form, no nav, no chrome.
- ✅ **Anonymous /survey/[id]/public (non-active)**: "This survey is closed" — single sentence, no chrome, no path back into the app.
- ✅ `pnpm typecheck`, `pnpm test` (24 pass), `pnpm build` (`/survey` + `/survey/[id]/public` both registered).

## Two things explicitly deferred (separate PRs)
- **Results chart for state 5.** Right now state 5 shows the user's picks but no aggregate visualization. The port from the original React/Vite project is its own discrete piece of work and is the cleanest cut point.
- **Anonymous → signup carry-over.** The design-doc decision was "carry over" (anonymous response becomes tied to the new user on signup). Implementing it requires a signed cookie binding the submission to the upcoming session AND a hook in the onboarding flow to consume that cookie. Both surfaces aren't touched here, so I left it as a TODO. Filed below as an open question if you want a follow-up issue.

Closes https://github.com/langermank/reality-stock-watch-app/issues/41

🤖 Generated with [Claude Code](https://claude.com/claude-code)