### PR TITLE
feat: carry an anonymous survey submission over to the user's account on signup (#80)

### DIFF
--- a/app/(auth)/login/LoginForm.tsx
+++ b/app/(auth)/login/LoginForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
+import { claimAnonymousSurveyResponse } from "@/lib/survey/claim";
 
 type Mode = "sign_in" | "sign_up";
 
@@ -42,6 +43,14 @@ export function LoginForm() {
       } else {
         const { error } = await supabase.auth.signInWithPassword({ email, password });
         if (error) throw error;
+        // Carry over an anonymous survey submission to this account if the
+        // cookie is around (#80). Email+password sign-in skips /auth/callback,
+        // so the claim has to fire here. Best-effort; failures don't block sign-in.
+        try {
+          await claimAnonymousSurveyResponse();
+        } catch {
+          /* swallow */
+        }
         router.push("/market");
       }
     } catch (err: unknown) {

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
+import { claimAnonymousSurveyResponse } from "@/lib/survey/claim";
 
 /** Handles OAuth and email confirmation redirects from Supabase. */
 export async function GET(request: NextRequest) {
@@ -35,6 +36,10 @@ export async function GET(request: NextRequest) {
   if (error) {
     return NextResponse.redirect(`${origin}/login?error=auth_failed`);
   }
+
+  // Carry over any anonymous survey submission to the newly authenticated user
+  // (#80). The action reads the cookie + auth session itself; we just invoke.
+  await claimAnonymousSurveyResponse();
 
   return NextResponse.redirect(`${origin}${next}`);
 }

--- a/lib/survey/actions.ts
+++ b/lib/survey/actions.ts
@@ -9,14 +9,21 @@
 //   - submitAnonymousResponse: public-link user. Uses the service-role client
 //     (server-only) because there is no RLS INSERT policy for the anon role,
 //     and we validate the survey is `active` ourselves. user_id stays null
-//     and is_anonymous = true.
+//     and is_anonymous = true. On success, sets a signed cookie carrying the
+//     new response id so a subsequent signup can retroactively claim it (#80).
 //
 // Both write the `answers` jsonb as { [questionId]: answer } where answer is
 // a string (single_choice), string[] (multiple_choice), or string[] (ranking,
 // best-first). Names are stored — matching the seed and the design doc.
 
+import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { serviceClient } from "@/lib/supabase/service";
+import {
+  ANON_SURVEY_COOKIE,
+  ANON_SURVEY_COOKIE_MAX_AGE_SECONDS,
+  buildAnonSurveyCookieValue,
+} from "./anon-cookie";
 
 export type AnswerValue = string | string[];
 
@@ -80,12 +87,28 @@ export async function submitAnonymousResponse(
   if (survey.status !== "active") return { ok: false, error: "not-active" };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (serviceClient.from("survey_responses") as any).insert({
-    survey_id: surveyId,
-    user_id: null,
-    answers,
-    is_anonymous: true,
+  const { data: inserted, error } = await (serviceClient.from("survey_responses") as any)
+    .insert({
+      survey_id: surveyId,
+      user_id: null,
+      answers,
+      is_anonymous: true,
+    })
+    .select("id")
+    .single();
+  if (error || !inserted?.id) return { ok: false, error: "unknown" };
+
+  // Drop a signed cookie so a subsequent signup can claim this response
+  // (consumed in app/auth/callback/route.ts). Same-site=lax so the cookie
+  // survives OAuth round-trips; httpOnly so client JS can't read it.
+  const cookieStore = await cookies();
+  cookieStore.set(ANON_SURVEY_COOKIE, buildAnonSurveyCookieValue(inserted.id as string), {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: ANON_SURVEY_COOKIE_MAX_AGE_SECONDS,
   });
-  if (error) return { ok: false, error: "unknown" };
+
   return { ok: true };
 }

--- a/lib/survey/anon-cookie.test.ts
+++ b/lib/survey/anon-cookie.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { buildAnonSurveyCookieValue, readAnonSurveyCookieValue } from "./anon-cookie";
+
+// The helper signs with SUPABASE_SERVICE_ROLE_KEY. Stamp a deterministic value
+// for the test so we don't depend on whatever the test runner inherits.
+const ORIGINAL = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+beforeAll(() => {
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "test-secret-test-secret-test-secret";
+});
+afterAll(() => {
+  if (ORIGINAL === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  else process.env.SUPABASE_SERVICE_ROLE_KEY = ORIGINAL;
+});
+
+const RESPONSE_ID = "11111111-2222-3333-4444-555555555555";
+
+describe("anon-survey cookie", () => {
+  it("round-trips a valid cookie", () => {
+    const value = buildAnonSurveyCookieValue(RESPONSE_ID);
+    expect(readAnonSurveyCookieValue(value)).toBe(RESPONSE_ID);
+  });
+
+  it("rejects undefined / null / empty", () => {
+    expect(readAnonSurveyCookieValue(undefined)).toBeNull();
+    expect(readAnonSurveyCookieValue(null)).toBeNull();
+    expect(readAnonSurveyCookieValue("")).toBeNull();
+  });
+
+  it("rejects malformed values (no signature separator)", () => {
+    expect(readAnonSurveyCookieValue("no-dot-anywhere")).toBeNull();
+    expect(readAnonSurveyCookieValue(`${RESPONSE_ID}.`)).toBeNull();
+    expect(readAnonSurveyCookieValue(`.${RESPONSE_ID}`)).toBeNull();
+  });
+
+  it("rejects a tampered response id", () => {
+    const value = buildAnonSurveyCookieValue(RESPONSE_ID);
+    // Flip the payload but keep the original signature.
+    const sigStart = value.indexOf(".");
+    const tampered = `${RESPONSE_ID.replace("1", "9")}${value.slice(sigStart)}`;
+    expect(readAnonSurveyCookieValue(tampered)).toBeNull();
+  });
+
+  it("rejects a wrong signature", () => {
+    const value = buildAnonSurveyCookieValue(RESPONSE_ID);
+    const sigStart = value.indexOf(".");
+    const tampered = `${value.slice(0, sigStart)}.AAAA${value.slice(sigStart + 1)}`;
+    expect(readAnonSurveyCookieValue(tampered)).toBeNull();
+  });
+
+  it("rejects a signature from a different secret", () => {
+    const value = buildAnonSurveyCookieValue(RESPONSE_ID);
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "different-secret-different-secret";
+    expect(readAnonSurveyCookieValue(value)).toBeNull();
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-secret-test-secret-test-secret";
+  });
+});

--- a/lib/survey/anon-cookie.ts
+++ b/lib/survey/anon-cookie.ts
@@ -1,0 +1,65 @@
+// Signed-cookie helper for the anon→signup carry-over (issue #80).
+//
+// When a fan submits the public survey anonymously and then signs up, we want
+// to retroactively tie the existing `survey_responses` row to the new user
+// instead of leaving them detached. The bridge is a short-lived signed cookie:
+//   - anon submit  → set cookie carrying the response id (1h httpOnly sameSite=lax)
+//   - auth callback → read + verify cookie, update the row, clear the cookie
+//
+// HMAC-SHA256 with `SUPABASE_SERVICE_ROLE_KEY` as the signing secret. That key
+// is already a required server-only env var, so this introduces no new secret
+// to manage. Cookie format: `<responseId>.<base64url-hmac>` — readable in dev
+// tools, tamper-evident, and trivial to verify with constant-time comparison.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export const ANON_SURVEY_COOKIE = "rsw_anon_survey";
+
+/** 1 hour — long enough for a leisurely OAuth signup, short enough that an
+ *  abandoned anon submission doesn't loiter forever. */
+export const ANON_SURVEY_COOKIE_MAX_AGE_SECONDS = 60 * 60;
+
+function signingKey(): Buffer {
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!key) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY is required to sign anon-survey cookies");
+  }
+  return Buffer.from(key, "utf8");
+}
+
+function sign(payload: string): string {
+  return createHmac("sha256", signingKey())
+    .update(payload)
+    .digest("base64url");
+}
+
+export function buildAnonSurveyCookieValue(responseId: string): string {
+  return `${responseId}.${sign(responseId)}`;
+}
+
+/**
+ * Verify the cookie and return the embedded response id if valid, else null.
+ * Returns null for any tampering / malformed input — never throws — so callers
+ * can treat "no valid cookie" and "no cookie" uniformly.
+ */
+export function readAnonSurveyCookieValue(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  const dot = raw.indexOf(".");
+  if (dot < 0) return null;
+  const responseId = raw.slice(0, dot);
+  const provided = raw.slice(dot + 1);
+  if (!responseId || !provided) return null;
+
+  const expected = sign(responseId);
+  // Constant-time compare. timingSafeEqual requires equal lengths.
+  let expectedBuf: Buffer;
+  let providedBuf: Buffer;
+  try {
+    expectedBuf = Buffer.from(expected, "base64url");
+    providedBuf = Buffer.from(provided, "base64url");
+  } catch {
+    return null;
+  }
+  if (expectedBuf.length !== providedBuf.length) return null;
+  return timingSafeEqual(expectedBuf, providedBuf) ? responseId : null;
+}

--- a/lib/survey/claim.ts
+++ b/lib/survey/claim.ts
@@ -1,0 +1,68 @@
+"use server";
+
+// Anon → signup carry-over (#80) — server action.
+//
+// Called from any path that lands an authenticated user with a still-valid
+// anon-survey cookie:
+//   - /auth/callback  (OAuth + email-confirmation signups — earliest hit)
+//   - LoginForm       (email+password sign-ins that skip /auth/callback)
+//
+// "use server" because we need to mutate cookies (delete the consumed one).
+// Server components can't do that — only server actions and route handlers.
+// Idempotent: cookie is single-use, so concurrent calls converge — the second
+// one finds no cookie and bails.
+
+import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+import { serviceClient } from "@/lib/supabase/service";
+import { ANON_SURVEY_COOKIE, readAnonSurveyCookieValue } from "./anon-cookie";
+
+/** Try to attach the anonymous survey response identified by the cookie to
+ *  the currently authenticated user. Silently does nothing if there's no
+ *  user, no valid cookie, the row no longer qualifies, or the user already
+ *  has a response for that survey. */
+export async function claimAnonymousSurveyResponse(): Promise<void> {
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(ANON_SURVEY_COOKIE)?.value;
+  const responseId = readAnonSurveyCookieValue(raw);
+  if (!responseId) {
+    if (raw) cookieStore.delete(ANON_SURVEY_COOKIE);
+    return;
+  }
+  // Always drop the cookie — single-use, succeed or not.
+  cookieStore.delete(ANON_SURVEY_COOKIE);
+
+  // Authenticate via the user-scoped server client (reads the session cookie).
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+
+  // Read the row via service client — the row is still anonymous so the
+  // user-scoped read policy doesn't apply yet (owners only).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: rowRaw } = await (serviceClient.from("survey_responses") as any)
+    .select("id, survey_id, user_id, is_anonymous")
+    .eq("id", responseId)
+    .maybeSingle();
+  const row = rowRaw as
+    | { id: string; survey_id: string; user_id: string | null; is_anonymous: boolean }
+    | null;
+  if (!row || !row.is_anonymous || row.user_id) return;
+
+  // Skip if the user already has a response for this survey — the per-user
+  // unique index would block the update anyway. Their original submission
+  // wins; the anonymous one stays anonymous.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { count } = await (serviceClient.from("survey_responses") as any)
+    .select("id", { count: "exact", head: true })
+    .eq("survey_id", row.survey_id)
+    .eq("user_id", user.id);
+  if ((count ?? 0) > 0) return;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (serviceClient.from("survey_responses") as any)
+    .update({ user_id: user.id, is_anonymous: false })
+    .eq("id", row.id);
+}

--- a/lib/survey/source.ts
+++ b/lib/survey/source.ts
@@ -8,6 +8,7 @@
 // survey-open and the user's load is simply absent).
 
 import { createClient } from "@/lib/supabase/server";
+import { serviceClient } from "@/lib/supabase/service";
 
 export type QuestionType = "ranking" | "multiple_choice" | "single_choice";
 
@@ -111,9 +112,12 @@ async function pickRelevantSurvey(seasonId: string): Promise<SurveyRow | null> {
   return ((publishedRows as SurveyRow[] | null)?.[0]) ?? null;
 }
 
-async function loadActiveContestantNames(seasonId: string): Promise<string[]> {
-  const supabase = await createClient();
-  const { data } = await supabase
+async function loadActiveContestantNames(
+  seasonId: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  client: any,
+): Promise<string[]> {
+  const { data } = await client
     .from("contestants")
     .select("name, status")
     .eq("season_id", seasonId)
@@ -147,7 +151,7 @@ export async function getSurveyPageState(userId: string): Promise<SurveyPageStat
   // we render from `answers` alone, treating it as opaque key/value.
   let questions: SurveyQuestion[] = [];
   if (survey.status === "active" || survey.status === "results_published") {
-    questions = await loadQuestions(survey.id, season.id);
+    questions = await loadQuestions(survey.id, season.id, supabase);
   }
 
   // Did this user submit?
@@ -181,13 +185,18 @@ export async function getSurveyPageState(userId: string): Promise<SurveyPageStat
   return { kind: "no-active" }; // draft — treat as none
 }
 
-/** Load + resolve questions for the survey (used by both logged-in & public routes). */
+/** Load + resolve questions for the survey. Caller passes the client so the
+ *  logged-in path can use the user-scoped client (RLS-checked) and the anon
+ *  public path can use the service client (the route's status check IS the
+ *  gate; RLS would otherwise block anon entirely). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function loadQuestions(
   surveyId: string,
   seasonId: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  client: any,
 ): Promise<SurveyQuestion[]> {
-  const supabase = await createClient();
-  const { data } = await supabase
+  const { data } = await client
     .from("survey_questions")
     .select("id, text, type, display_order, options, uses_contestants")
     .eq("survey_id", surveyId)
@@ -197,7 +206,7 @@ export async function loadQuestions(
 
   // Resolve contestant lists once if any question needs them.
   const needsContestants = rows.some((row) => row.uses_contestants);
-  const contestants = needsContestants ? await loadActiveContestantNames(seasonId) : [];
+  const contestants = needsContestants ? await loadActiveContestantNames(seasonId, client) : [];
 
   return rows.map((row) => ({
     id: row.id,
@@ -211,14 +220,18 @@ export async function loadQuestions(
 
 /** Public-link loader: the survey, its questions, and a closed/active flag.
  *  Surfaces the "closed/published" state separately so the public route can
- *  show "this survey is closed" without exposing user-only views. */
+ *  show "this survey is closed" without exposing user-only views.
+ *
+ *  Uses the service client because the anon role has no read policy on
+ *  surveys/survey_questions/contestants. The status check below IS the gate
+ *  (only `active` surveys expose questions to anonymous users). */
 export async function getPublicSurvey(surveyId: string): Promise<
   | { kind: "active"; survey: SurveyMeta; questions: SurveyQuestion[] }
   | { kind: "closed"; survey: SurveyMeta }
   | null
 > {
-  const supabase = await createClient();
-  const { data } = await supabase
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data } = await (serviceClient as any)
     .from("surveys")
     .select("id, title, week_number, status, closes_at, season_id")
     .eq("id", surveyId)
@@ -235,7 +248,7 @@ export async function getPublicSurvey(surveyId: string): Promise<
   };
 
   if (row.status === "active") {
-    const questions = await loadQuestions(row.id, row.season_id);
+    const questions = await loadQuestions(row.id, row.season_id, serviceClient);
     return { kind: "active", survey: meta, questions };
   }
   // closed / results_published / draft → all "closed" from anon perspective


### PR DESCRIPTION
Closes #80. When a fan submits the public survey anonymously and then creates / signs into an account, their existing `survey_responses` row is retroactively attached to the new user instead of being permanently anonymous. The transition is invisible to the user — they sign in, and their submission is already there in their account.

## How it works
1. **Anonymous submit** (`lib/survey/actions.ts:submitAnonymousResponse`) inserts the row via service client, then sets a signed cookie `rsw_anon_survey=<id>.<hmac>` carrying the new response id. 1h TTL, httpOnly, `sameSite=lax` so the cookie survives OAuth redirects.
2. **Claim** (`lib/survey/claim.ts`, `"use server"`) reads + verifies the cookie, looks up the row via service client (the anon row's owner-only RLS doesn't permit reads yet — chicken-and-egg), skips if the new user already has a response for that survey (per-user unique index would block anyway), otherwise UPDATEs `user_id + is_anonymous=false`. Cookie is single-use — always cleared whether the claim succeeds or not.
3. **Claim runs in two places** so every auth path is covered:
   - `/auth/callback` (Route Handler) — OAuth + email-confirmation signups
   - `LoginForm` (client → server action) — email+password sign-ins that skip `/auth/callback` entirely
4. **Signing**: HMAC-SHA256 with `SUPABASE_SERVICE_ROLE_KEY` as the secret — already a required server-only env var, no new secret to manage. Cookie format: `<responseId>.<base64url-hmac>`.

## Drive-by fix
`getPublicSurvey` in `lib/survey/source.ts` was using the user-scoped Supabase client, but the `anon` role has no read policy on `surveys` — so the anonymous `/survey/[id]/public` route was effectively broken (it only worked while an admin session lingered in the browser, which is why my #41 verification didn't catch it). Switched it to the service-role client; the route's own `status === 'active'` check is the gate.

## What I learned the hard way
First implementation put the claim in `(app)/layout.tsx` to cover the email+password path. **That crashes** — server components can read cookies but can't modify them, only Server Actions and Route Handlers can. Refactored the claim into a `"use server"` action callable from anywhere (and updated `LoginForm` to call it before `router.push("/market")`). Caught via the debug logs the layout-level approach produced before I tore it out.

## Verification (local, real flow)
1. ✅ Signed out admin, visited `/survey/<active>/public` as anonymous → form renders standalone, submitted "Veto Competition"
2. ✅ DB row inserted: `is_anonymous=true, user_id=null`, signed cookie set in browser
3. ✅ Signed in as Tara (email+password — exercises the LoginForm path that doesn't hit `/auth/callback`)
4. ✅ Same DB row now `is_anonymous=false, user_id=<Tara>` — carry-over fired
5. ✅ Tara visits `/survey` → sees "Thanks for your response!" + her picks (Veto Competition). Submission is hers from her POV.

Also:
- ✅ `pnpm typecheck`, `pnpm test` (11 pass — 6 new for the cookie sign/verify round-trip + tampering + wrong secret), `pnpm build` clean
- Cookie test covers: round-trip, tampered responseId, tampered signature, wrong secret, missing/empty/malformed values

## Edge cases handled
- User signs into an account that already has a response for this survey → claim skips, cookie cleared, both rows preserved (the original wins, the anonymous one stays anonymous)
- Cookie tampered → signature check fails, treated as no cookie
- User abandons signup → cookie expires after 1h
- Concurrent claims → idempotent (cookie is single-use, second call sees no cookie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)