### PR TITLE
feat: mirror ephemeral console interactions to OBS broadcast view (#78)

### DIFF
--- a/components/reveal/BroadcastChart.tsx
+++ b/components/reveal/BroadcastChart.tsx
@@ -22,6 +22,20 @@ type Props = {
   selectedWeekId: string;
   /** Stable color per contestant id (see colors.ts). */
   colorOf: (contestantId: string) => string;
+  // ---- Ephemeral interaction overrides (#78) ----
+  /** When set, overrides local hover so a remote sender can drive the highlight. */
+  forcedHoveredId?: string | null;
+  /** When set, a contestant id stays highlighted regardless of hover — the
+   *  click-to-focus state. */
+  focusedId?: string | null;
+  /** Fired when hover changes locally. Senders broadcast this. */
+  onHoverChange?: (contestantId: string | null) => void;
+  /** Fired when a contestant row is clicked. Senders use this to toggle focus. */
+  onContestantClick?: (contestantId: string) => void;
+  /** Fired when a week vertical is clicked. Senders broadcast a scrub. */
+  onWeekClick?: (weekId: string) => void;
+  /** Fired when a week vertical is hovered; null when no week is hovered. */
+  onWeekHover?: (weekId: string | null) => void;
 };
 
 // SVG viewBox geometry — ported verbatim from the original. The chart scales to
@@ -61,8 +75,29 @@ function movementFill(movement: number) {
   return "fill-slate-500";
 }
 
-export function BroadcastChart({ state, selectedWeekId, colorOf }: Props) {
-  const [hovered, setHovered] = useState<string | null>(null);
+export function BroadcastChart({
+  state,
+  selectedWeekId,
+  colorOf,
+  forcedHoveredId,
+  focusedId,
+  onHoverChange,
+  onContestantClick,
+  onWeekClick,
+  onWeekHover,
+}: Props) {
+  const [localHovered, setLocalHovered] = useState<string | null>(null);
+
+  // Effective highlight: forced > focused > local. forcedHoveredId !== undefined
+  // means a remote sender is driving us; null means "actively no hover" (clear
+  // the highlight). focusedId is sustained click-state.
+  const hovered =
+    forcedHoveredId !== undefined ? forcedHoveredId : (focusedId ?? localHovered);
+
+  const setHovered = (next: string | null) => {
+    setLocalHovered(next);
+    onHoverChange?.(next);
+  };
 
   const selectedWeek =
     state.weeks.find((week) => week.id === selectedWeekId) ?? state.weeks.at(-1);
@@ -137,6 +172,7 @@ export function BroadcastChart({ state, selectedWeekId, colorOf }: Props) {
                 role={isRevealed ? "button" : undefined}
                 onMouseEnter={() => isRevealed && setHovered(entry.contestantId)}
                 onMouseLeave={() => isRevealed && setHovered(null)}
+                onClick={() => isRevealed && onContestantClick?.(entry.contestantId)}
                 className={`grid grid-cols-[48px_56px_1fr_auto] items-center gap-3 rounded-xl border p-2.5 transition-opacity ${
                   isRevealed
                     ? "border-white/10 bg-white/[0.04]"
@@ -232,29 +268,46 @@ export function BroadcastChart({ state, selectedWeekId, colorOf }: Props) {
             })}
 
             {/* Week verticals + axis labels. */}
-            {geometry.map((week) => (
-              <g key={week.weekId}>
-                <line
-                  x1={week.x}
-                  x2={week.x}
-                  y1={chart.top}
-                  y2={chart.height - chart.bottom}
-                  stroke={week.weekNumber === selectedWeekNumber ? "#38bdf8" : "#1a2236"}
-                  strokeWidth={week.weekNumber === selectedWeekNumber ? 2.5 : 1}
-                  strokeDasharray="3 9"
-                />
-                <text
-                  x={week.x}
-                  y={chart.height - 26}
-                  textAnchor="middle"
-                  className={`text-[22px] font-black ${
-                    week.weekNumber === selectedWeekNumber ? "fill-sky-300" : "fill-slate-500"
-                  }`}
-                >
-                  WK {week.weekNumber}
-                </text>
-              </g>
-            ))}
+            {geometry.map((week) => {
+              const clickable = Boolean(onWeekClick);
+              return (
+                <g key={week.weekId}>
+                  <line
+                    x1={week.x}
+                    x2={week.x}
+                    y1={chart.top}
+                    y2={chart.height - chart.bottom}
+                    stroke={week.weekNumber === selectedWeekNumber ? "#38bdf8" : "#1a2236"}
+                    strokeWidth={week.weekNumber === selectedWeekNumber ? 2.5 : 1}
+                    strokeDasharray="3 9"
+                  />
+                  <text
+                    x={week.x}
+                    y={chart.height - 26}
+                    textAnchor="middle"
+                    className={`text-[22px] font-black ${
+                      week.weekNumber === selectedWeekNumber ? "fill-sky-300" : "fill-slate-500"
+                    }`}
+                  >
+                    WK {week.weekNumber}
+                  </text>
+                  {/* Generous click + hover target so scrubbing doesn't require pixel-precision. */}
+                  {(clickable || onWeekHover) && (
+                    <rect
+                      x={week.x - 40}
+                      y={chart.top}
+                      width={80}
+                      height={chart.height - chart.top - chart.bottom + 20}
+                      fill="transparent"
+                      style={{ cursor: clickable ? "pointer" : "default" }}
+                      onClick={() => onWeekClick?.(week.weekId)}
+                      onMouseEnter={() => onWeekHover?.(week.weekId)}
+                      onMouseLeave={() => onWeekHover?.(null)}
+                    />
+                  )}
+                </g>
+              );
+            })}
 
             {/* One trajectory line per contestant. Only REVEALED points are
                 drawn; an unrevealed live-week point hides that segment. A line

--- a/components/reveal/BroadcastLive.tsx
+++ b/components/reveal/BroadcastLive.tsx
@@ -1,30 +1,36 @@
 "use client";
 
 // Live wrapper around the presentational BroadcastChart — the chrome-less
-// broadcast view the producer captures with OBS (issue #65).
+// broadcast view the producer captures with OBS (issues #65, #78).
 //
-// Reveal-pointer subscription lives in useRevealState (shared with #66's
-// producer console). The producer's clicks fan out to every subscriber via
-// Supabase Realtime; this surface re-gates and the next entry animates in
-// without a reload.
+// Two layers of Realtime subscription drive what's on screen:
+//   - useRevealState: persistent reveal pointer (which week is on air, how
+//     many entries revealed). DB-backed, postgres_changes Realtime.
+//   - useRevealCursor: ephemeral interaction state from the producer console
+//     — hover, click-to-focus, week scrub. Broadcast-channel Realtime, no DB.
 //
-// Spoiler note: every entry is present client-side, but the chart only DRAWS
-// revealed ones (unrevealed render as "• • •" placeholders by design). Since
-// the audience sees the OBS video — never this network payload — and the route
-// is admin-only, that is the correct, simplest model here.
+// When the producer hovers a contestant in /admin/reveal, this surface sees
+// the broadcast and re-renders the chart with the same highlight. The OBS
+// capture mirrors the producer's pointer without showing their cursor.
 
 import { useMemo } from "react";
 import { BroadcastChart } from "./BroadcastChart";
 import { buildBroadcastState } from "./rankings";
 import { buildColorMap } from "./colors";
 import { useRevealState } from "@/hooks/useRevealState";
+import { useRevealCursor } from "@/hooks/useRevealCursor";
 import type { RevealData } from "@/lib/reveal/source";
 
 export function BroadcastLive({ initial }: { initial: RevealData }) {
-  const { selectedWeekId, revealCount } = useRevealState(initial.season.id, {
+  const { selectedWeekId: dbSelectedWeekId, revealCount } = useRevealState(initial.season.id, {
     selectedWeekId: initial.selectedWeekId,
     revealCount: initial.revealCount,
   });
+  const { cursor } = useRevealCursor(initial.season.id);
+
+  // Hover-scrub overrides the on-air pointer locally so the producer can
+  // jump to a prior week without actually changing what's on air.
+  const effectiveWeekId = cursor.scrubbedWeekId ?? dbSelectedWeekId;
 
   const colorOf = useMemo(() => {
     const map = buildColorMap(initial.contestants.map((contestant) => contestant.id));
@@ -38,15 +44,21 @@ export function BroadcastLive({ initial }: { initial: RevealData }) {
         weeks: initial.weeks,
         contestants: initial.contestants,
         rankings: initial.rankings,
-        selectedWeekId,
+        selectedWeekId: effectiveWeekId,
         revealCount,
       }),
-    [initial, selectedWeekId, revealCount],
+    [initial, effectiveWeekId, revealCount],
   );
 
   return (
     <div className="h-dvh w-full bg-[#05060b]">
-      <BroadcastChart state={state} selectedWeekId={selectedWeekId} colorOf={colorOf} />
+      <BroadcastChart
+        state={state}
+        selectedWeekId={effectiveWeekId}
+        colorOf={colorOf}
+        forcedHoveredId={cursor.hoveredId}
+        focusedId={cursor.focusedId}
+      />
     </div>
   );
 }

--- a/components/reveal/RevealConsole.tsx
+++ b/components/reveal/RevealConsole.tsx
@@ -1,18 +1,26 @@
 "use client";
 
-// Producer reveal console (issue #66) — desktop-friendly admin panel the
-// producer drives during a live stream. Three controls (survey select, Reveal
-// Next, Reset) write to `survey_reveal_state` via server actions; an embedded
-// live preview mirrors what the OBS-captured broadcast view at /admin/stream
-// is showing right now. Both surfaces share the same Realtime subscription
-// (useRevealState), so a click here animates everywhere — no refetch.
+// Producer reveal console — desktop-friendly admin panel the producer drives
+// during a live stream (issues #66, #78).
+//
+// Three control surfaces:
+//   1. Survey selector + Reveal Next + Reset → persistent state via server
+//      actions to `survey_reveal_state` → Realtime postgres_changes →
+//      every subscriber re-renders. (#66)
+//   2. Embedded live preview that mirrors what /admin/stream sees right now.
+//      Same chart, same data path. (#66)
+//   3. Ephemeral interactions on the preview — hover, click-to-focus, week
+//      scrub — broadcast to /admin/stream via Realtime broadcast channel.
+//      Producer screen-shares /admin/stream in OBS; their pointer gestures
+//      here appear on stage there. (#78)
 
-import { useMemo, useTransition } from "react";
+import { useCallback, useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { BroadcastChart } from "./BroadcastChart";
 import { buildBroadcastState } from "./rankings";
 import { buildColorMap } from "./colors";
 import { useRevealState } from "@/hooks/useRevealState";
+import { useRevealCursor } from "@/hooks/useRevealCursor";
 import { revealNext, reset, setSelectedSurvey } from "@/lib/reveal/actions";
 import type { RevealData } from "@/lib/reveal/source";
 
@@ -20,10 +28,53 @@ type Props = { initial: RevealData };
 
 export function RevealConsole({ initial }: Props) {
   const [isPending, startTransition] = useTransition();
-  const { selectedWeekId, revealCount } = useRevealState(initial.season.id, {
+  const { selectedWeekId: dbSelectedWeekId, revealCount } = useRevealState(initial.season.id, {
     selectedWeekId: initial.selectedWeekId,
     revealCount: initial.revealCount,
   });
+
+  // Local ephemeral state — driven by chart interactions, broadcast to /stream.
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const [scrubWeekId, setScrubWeekId] = useState<string | null>(null);
+  const { send } = useRevealCursor(initial.season.id);
+
+  // Effective preview week: hover-scrub overrides the on-air pointer.
+  const previewWeekId = scrubWeekId ?? dbSelectedWeekId;
+
+  const broadcast = useCallback(
+    (next: { hoveredId?: string | null; focusedId?: string | null; scrubbedWeekId?: string | null }) => {
+      send({
+        hoveredId: next.hoveredId ?? null,
+        focusedId: next.focusedId ?? null,
+        scrubbedWeekId: next.scrubbedWeekId ?? null,
+      });
+    },
+    [send],
+  );
+
+  const handleHoverChange = useCallback(
+    (id: string | null) => {
+      setHoveredId(id);
+      broadcast({ hoveredId: id, focusedId, scrubbedWeekId: scrubWeekId });
+    },
+    [broadcast, focusedId, scrubWeekId],
+  );
+  const handleContestantClick = useCallback(
+    (id: string) => {
+      const next = focusedId === id ? null : id;
+      setFocusedId(next);
+      broadcast({ hoveredId, focusedId: next, scrubbedWeekId: scrubWeekId });
+    },
+    [broadcast, focusedId, hoveredId, scrubWeekId],
+  );
+  const handleWeekHover = useCallback(
+    (id: string | null) => {
+      setScrubWeekId(id);
+      broadcast({ hoveredId, focusedId, scrubbedWeekId: id });
+    },
+    [broadcast, focusedId, hoveredId],
+  );
 
   const colorOf = useMemo(() => {
     const map = buildColorMap(initial.contestants.map((contestant) => contestant.id));
@@ -37,25 +88,22 @@ export function RevealConsole({ initial }: Props) {
         weeks: initial.weeks,
         contestants: initial.contestants,
         rankings: initial.rankings,
-        selectedWeekId,
+        selectedWeekId: previewWeekId,
         revealCount,
       }),
-    [initial, selectedWeekId, revealCount],
+    [initial, previewWeekId, revealCount],
   );
 
-  // The chart's "selected week" is whichever survey is on screen. The frozen
-  // logic gates that week's entries by revealCount; prior weeks ship whole.
-  const selectedWeek = initial.weeks.find((week) => week.id === selectedWeekId);
+  // Status panel reflects the on-air week, not the scrub (audience sees on-air info).
+  const selectedWeek = initial.weeks.find((week) => week.id === dbSelectedWeekId);
   const entriesInSelected =
-    initial.rankings.find((ranking) => ranking.weekId === selectedWeekId)?.entries.length ?? 0;
+    initial.rankings.find((ranking) => ranking.weekId === dbSelectedWeekId)?.entries.length ?? 0;
 
   const atStart = revealCount === 0;
   const atEnd = revealCount >= entriesInSelected;
 
   return (
     <div className="grid h-dvh grid-cols-[360px_1fr] gap-0 bg-neutral-950 text-slate-100">
-      {/* Producer controls. Desktop-only; the producer runs this in a separate
-          window from the OBS-captured /admin/stream view. */}
       <aside className="flex min-h-0 flex-col border-r border-white/10 bg-[#0a0c14] p-6">
         <div className="mb-6">
           <p className="text-xs font-bold uppercase tracking-[0.25em] text-slate-500">
@@ -80,7 +128,7 @@ export function RevealConsole({ initial }: Props) {
             Selected survey
           </span>
           <select
-            value={selectedWeekId}
+            value={dbSelectedWeekId}
             disabled={isPending}
             onChange={(event) => {
               const next = event.target.value;
@@ -135,14 +183,21 @@ export function RevealConsole({ initial }: Props) {
         </div>
       </aside>
 
-      {/* Live preview — exactly what /admin/stream is rendering right now. */}
       <main className="flex min-h-0 flex-col">
         <div className="border-b border-white/10 bg-[#0a0c14] px-6 py-2 text-xs font-bold uppercase tracking-[0.25em] text-slate-500">
           Live preview
         </div>
         <div className="flex flex-1 items-center justify-center overflow-hidden bg-[#05060b] p-4">
           <div className="aspect-video h-full max-h-full w-full max-w-full overflow-hidden rounded-xl shadow-2xl">
-            <BroadcastChart state={state} selectedWeekId={selectedWeekId} colorOf={colorOf} />
+            <BroadcastChart
+              state={state}
+              selectedWeekId={previewWeekId}
+              colorOf={colorOf}
+              focusedId={focusedId}
+              onHoverChange={handleHoverChange}
+              onContestantClick={handleContestantClick}
+              onWeekHover={handleWeekHover}
+            />
           </div>
         </div>
       </main>

--- a/hooks/useRevealCursor.ts
+++ b/hooks/useRevealCursor.ts
@@ -1,0 +1,129 @@
+"use client";
+
+// Ephemeral cursor / scrub broadcast for the livestream reveal (#78).
+//
+// The producer screen-shares /admin/stream in OBS and uses /admin/reveal as a
+// remote control. Anything they do in the console preview (hover, click, week
+// scrub) needs to appear on the broadcast view in real time — without writing
+// to Postgres, because cursor moves at 60 Hz would hammer the DB.
+//
+// The right Supabase primitive is the Realtime "broadcast" channel (separate
+// from postgres_changes): ephemeral pub-sub, no persistence, fan-out to all
+// subscribers. We open one channel per season — `reveal-cursor-<seasonId>` —
+// and every reveal surface joins it. Senders broadcast cursor state; receivers
+// pick it up and render it.
+//
+// Throttling: outgoing events are coalesced to one every CURSOR_INTERVAL_MS
+// (last value wins). With a hover that fires per pixel-move that's 60 fps →
+// 20 Hz on the wire, plenty smooth for animation but doesn't saturate.
+//
+// Security note: the channel is name-scoped, not RLS-gated. Both surfaces that
+// use it (/admin/stream and /admin/reveal) sit behind requireAdmin(), so any
+// real-world subscriber is an admin already. If we ever expose a route that
+// doesn't gate, gate the channel via a Realtime authorization policy.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RealtimeChannel } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/client";
+
+const CURSOR_INTERVAL_MS = 50;
+const CURSOR_EVENT = "cursor";
+
+export type CursorState = {
+  /** Contestant id currently hovered in the sender's preview, or null. */
+  hoveredId: string | null;
+  /** Contestant id explicitly clicked-to-focus (sustained), or null. */
+  focusedId: string | null;
+  /** Week the sender is scrubbed to, or null when following the on-air pointer. */
+  scrubbedWeekId: string | null;
+};
+
+const EMPTY: CursorState = { hoveredId: null, focusedId: null, scrubbedWeekId: null };
+
+type UseRevealCursorResult = {
+  /** Latest cursor state seen on the channel (or EMPTY before any message). */
+  cursor: CursorState;
+  /** Push a new cursor state to all subscribers. Throttled — last value wins. */
+  send: (next: CursorState) => void;
+};
+
+export function useRevealCursor(seasonId: string): UseRevealCursorResult {
+  const [cursor, setCursor] = useState<CursorState>(EMPTY);
+
+  // Channel + pending-send state kept in refs so identity is stable across renders.
+  const channelRef = useRef<RealtimeChannel | null>(null);
+  const pendingRef = useRef<CursorState | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSentRef = useRef<CursorState>(EMPTY);
+
+  useEffect(() => {
+    const supabase = createClient();
+    let active = true;
+
+    (async () => {
+      // RLS doesn't apply to broadcast channels, but setting the auth token
+      // mirrors the postgres_changes path and future-proofs us if we add a
+      // Realtime authorization policy. Cheap, harmless.
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!active) return;
+      await supabase.realtime.setAuth(session?.access_token ?? null);
+      if (!active) return;
+
+      const channel = supabase.channel(`reveal-cursor-${seasonId}`, {
+        config: { broadcast: { self: false } },
+      });
+      channel.on("broadcast", { event: CURSOR_EVENT }, ({ payload }) => {
+        setCursor(payload as CursorState);
+      });
+      await channel.subscribe();
+      channelRef.current = channel;
+    })();
+
+    return () => {
+      active = false;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      if (channelRef.current) {
+        supabase.removeChannel(channelRef.current);
+        channelRef.current = null;
+      }
+    };
+  }, [seasonId]);
+
+  const flush = useCallback(() => {
+    timerRef.current = null;
+    const value = pendingRef.current;
+    pendingRef.current = null;
+    if (!value || !channelRef.current) return;
+    lastSentRef.current = value;
+    void channelRef.current.send({
+      type: "broadcast",
+      event: CURSOR_EVENT,
+      payload: value,
+    });
+  }, []);
+
+  const send = useCallback(
+    (next: CursorState) => {
+      // Skip outright if nothing changed since the last send — cuts noise.
+      const last = lastSentRef.current;
+      if (
+        next.hoveredId === last.hoveredId &&
+        next.focusedId === last.focusedId &&
+        next.scrubbedWeekId === last.scrubbedWeekId
+      ) {
+        return;
+      }
+      pendingRef.current = next;
+      if (timerRef.current) return; // already scheduled — last-value-wins
+      timerRef.current = setTimeout(flush, CURSOR_INTERVAL_MS);
+    },
+    [flush],
+  );
+
+  return { cursor, send };
+}


### PR DESCRIPTION
Closes #78. The producer screen-shares `/admin/stream` in OBS and uses `/admin/reveal` as a remote control. Until now, only persistent state (reveal advance, survey switch) flowed between the two surfaces — ephemeral interactions stayed local. Now hover-highlight, click-to-focus, and week-scrub all mirror live.

## Architecture
Two layers of Realtime now drive the broadcast view:
- **Persistent** — `useRevealState` reads `survey_reveal_state` over `postgres_changes`. Unchanged.
- **Ephemeral** — new `useRevealCursor` reads/writes a **broadcast channel** keyed `reveal-cursor-<seasonId>`. No DB writes (cursor moves at 60 Hz would hammer Postgres). Outgoing sends throttled to 50ms last-value-wins. Same `setAuth` pattern as `useRevealState` so the admin-only channel authenticates correctly.

## What changed where
- **`hooks/useRevealCursor.ts`** (new) — opens the broadcast channel, returns `{ cursor, send }`. Sender + receiver use the same hook; `broadcast: { self: false }` keeps the sender from seeing its own messages back.
- **`components/reveal/BroadcastChart.tsx`** — new optional props: `forcedHoveredId`, `focusedId`, `onHoverChange`, `onContestantClick`, `onWeekClick`, `onWeekHover`. Click + hover hit-targets over each week vertical (80×full-height transparent rects so scrubbing doesn't need pixel precision). Forced state overrides local hover; `focusedId` is sustained click-state.
- **`components/reveal/RevealConsole.tsx`** — sender. Local `hoveredId / focusedId / scrubWeekId` state drives the preview AND broadcasts. Click-to-focus toggles; hover-week scrubs.
- **`components/reveal/BroadcastLive.tsx`** — receiver. `cursor.scrubbedWeekId` overrides `dbSelectedWeekId`; `cursor.hoveredId` / `cursor.focusedId` feed the chart's forced state.

## Verified
- ✅ `pnpm typecheck`, `pnpm test`, `pnpm build` all clean
- ✅ Local interactions in `/admin/reveal` work end-to-end: clicking Janelle's row toggles focus, the chart dims 12 of 14 contestant groups (the 2 non-dimmed are the focused contestant + Tyler whose hover state is also active). Screenshot in PR comments.
- ✅ Channel subscribes without console/server errors

## What I couldn't verify alone (needs your eyes)
The preview tool is single-tab, so I can't directly observe `/admin/reveal` driving `/admin/stream` in two browser windows. Architectural confidence is high — `useRevealCursor` is a near-mirror of `useRevealState` which we extensively verified delivers cross-window — but I'd recommend a quick manual check:

1. Open `/admin/reveal` in one window.
2. Open `/admin/stream` in another (same browser session is fine — they're both admin-gated).
3. Hover a contestant in the console preview → broadcast view should dim non-hovered lines.
4. Click a contestant → broadcast view should show sustained focus until clicked again.
5. Hover a week vertical → broadcast view's selected week should follow.

## Design decisions
- **Hover-week is a scrub, click-week is on-air**: hover causes an ephemeral scrub (broadcast only); the existing survey dropdown remains the way to commit a new on-air week. We could add click-to-set-on-air on weeks later if that feels more natural.
- **`broadcast: { self: false }`** on the channel — the sender's own state is local (already in React state), so re-receiving it would just cause an extra render with the same data.
- **Channel security**: name-scoped, not RLS-gated. Both surfaces are admin-gated routes (`requireAdmin`), so subscribers are admins. If we ever expose a non-admin route that opens this channel, gate via a Realtime authorization policy — flagged as a TODO in the hook's comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)