### PR TITLE
feat: survey results visualization for state 5 (#79)

### DIFF
--- a/components/survey/SurveyView.tsx
+++ b/components/survey/SurveyView.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "next/navigation";
 import { SurveyForm } from "./SurveyForm";
 import { YourPicks } from "./YourPicks";
 import { PushPrompt } from "./PushPrompt";
+import { ResultsView } from "./results/ResultsView";
 import { submitResponse } from "@/lib/survey/actions";
 import type { SurveyMeta, SurveyPageState, SurveyQuestion } from "@/lib/survey/source";
 
@@ -150,17 +151,14 @@ export function SurveyView({ state }: { state: SurveyPageState }) {
   return (
     <Card>
       <SurveyHeader title={state.survey.title} weekNumber={state.survey.weekNumber} />
-      <div className="mb-6 rounded-2xl border border-white/10 bg-white/[0.04] p-5">
-        <p className="text-sm font-bold uppercase tracking-widest text-neutral-500">
-          Results
-        </p>
-        <p className="mt-2 text-sm text-neutral-400">
-          A full results chart is coming soon. Until then, your submitted picks
-          are below.
-        </p>
-      </div>
+      <p className="mb-4 text-xs font-bold uppercase tracking-widest text-neutral-500">
+        Results
+      </p>
+      <ResultsView results={state.results} />
       {state.answers && (
-        <YourPicks questions={state.questions} answers={state.answers} />
+        <div className="mt-6">
+          <YourPicks questions={state.questions} answers={state.answers} />
+        </div>
       )}
     </Card>
   );

--- a/components/survey/results/BarChart.tsx
+++ b/components/survey/results/BarChart.tsx
@@ -1,0 +1,60 @@
+// Shared bar chart for single_choice + multiple_choice survey results (#79).
+//
+// Restrained on purpose — the goal of #79 was to ship a working chart so the
+// design can be iterated without rewiring the data layer. Everything below
+// the // ---- presentation ---- marker is fair game to redesign.
+
+import type { ChoiceBucket } from "@/lib/survey/results";
+
+type Props = {
+  buckets: ChoiceBucket[];
+  /** Total responses, used to render the "N votes / X%" caption. */
+  responses: number;
+  /** If true, treat each respondent as potentially selecting multiple → caption phrasing. */
+  multi?: boolean;
+};
+
+export function BarChart({ buckets, responses, multi }: Props) {
+  if (buckets.length === 0) {
+    return (
+      <p className="text-sm text-neutral-500">No responses yet.</p>
+    );
+  }
+
+  // The max is what 100% of the bar represents. For single_choice this caps at
+  // responses; for multiple_choice the same option can stack up to responses too.
+  const max = Math.max(...buckets.map((b) => b.count), 1);
+
+  // ---- presentation ----
+  return (
+    <ul className="flex flex-col gap-2">
+      {buckets.map((bucket, index) => {
+        const widthPct = (bucket.count / max) * 100;
+        const isTop = index === 0 && bucket.count > 0;
+        return (
+          <li key={bucket.option} className="text-sm">
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="font-medium text-neutral-100 truncate">{bucket.option}</span>
+              <span className="tabular-nums text-neutral-400">
+                {bucket.count}
+                {multi ? null : (
+                  <span className="ml-1.5 text-xs text-neutral-500">
+                    · {Math.round(bucket.share * 100)}%
+                  </span>
+                )}
+              </span>
+            </div>
+            <div className="mt-1 h-2 overflow-hidden rounded-full bg-white/[0.04]">
+              <div
+                className={`h-full rounded-full transition-[width] ${
+                  isTop ? "bg-sky-400" : "bg-sky-500/40"
+                }`}
+                style={{ width: `${Math.max(widthPct, bucket.count === 0 ? 0 : 2)}%` }}
+              />
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/components/survey/results/RankingResults.tsx
+++ b/components/survey/results/RankingResults.tsx
@@ -1,0 +1,54 @@
+// Ranking-question results (#79).
+//
+// Shows Borda points as a bar chart with the average submitted position as a
+// companion stat. Same visual restraint as BarChart — redesign freely.
+
+import type { RankingBucket } from "@/lib/survey/results";
+
+type Props = {
+  buckets: RankingBucket[];
+  responses: number;
+};
+
+export function RankingResults({ buckets }: Props) {
+  if (buckets.length === 0) {
+    return <p className="text-sm text-neutral-500">No responses yet.</p>;
+  }
+
+  const max = Math.max(...buckets.map((b) => b.score), 1);
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {buckets.map((bucket) => {
+        const widthPct = (bucket.score / max) * 100;
+        const isTop = bucket.rank === 1;
+        return (
+          <li key={bucket.option} className="text-sm">
+            <div className="flex items-baseline gap-3">
+              <span className="grid h-6 w-7 shrink-0 place-items-center rounded text-xs font-bold tabular-nums text-neutral-300">
+                {bucket.rank}
+              </span>
+              <span className="flex-1 truncate font-medium text-neutral-100">
+                {bucket.option}
+              </span>
+              <span className="text-xs tabular-nums text-neutral-500">
+                avg #{bucket.averagePosition.toFixed(1)}
+              </span>
+              <span className="w-12 text-right tabular-nums text-neutral-400">
+                {bucket.score}
+              </span>
+            </div>
+            <div className="ml-10 mt-1 h-2 overflow-hidden rounded-full bg-white/[0.04]">
+              <div
+                className={`h-full rounded-full transition-[width] ${
+                  isTop ? "bg-emerald-400" : "bg-emerald-500/40"
+                }`}
+                style={{ width: `${widthPct}%` }}
+              />
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/components/survey/results/ResultsView.tsx
+++ b/components/survey/results/ResultsView.tsx
@@ -1,0 +1,56 @@
+// Survey results visualization for state 5 of /survey (#79).
+//
+// Receives the pre-aggregated `QuestionResults[]` from lib/survey/results.ts
+// and renders one chart per question. The aggregation layer is the contract
+// — when survey builder (#44) lands and real fans submit, this view doesn't
+// change; only the response count grows.
+//
+// Visual design intentionally restrained — see BarChart / RankingResults
+// for redesign-friendly markup.
+
+import type { QuestionResults } from "@/lib/survey/results";
+import { BarChart } from "./BarChart";
+import { RankingResults } from "./RankingResults";
+
+type Props = {
+  results: QuestionResults[];
+};
+
+export function ResultsView({ results }: Props) {
+  if (results.length === 0) {
+    return (
+      <p className="rounded-2xl border border-white/10 bg-white/[0.02] p-5 text-sm text-neutral-400">
+        No questions for this survey.
+      </p>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-6">
+      {results.map((result) => (
+        <article
+          key={result.question.id}
+          className="rounded-2xl border border-white/10 bg-white/[0.02] p-5"
+        >
+          <header className="mb-4 flex items-baseline justify-between gap-3">
+            <h3 className="text-base font-semibold text-neutral-100">
+              {result.question.text}
+            </h3>
+            <span className="text-xs tabular-nums text-neutral-500">
+              {result.responses} {result.responses === 1 ? "response" : "responses"}
+            </span>
+          </header>
+          {result.type === "ranking" ? (
+            <RankingResults buckets={result.buckets} responses={result.responses} />
+          ) : (
+            <BarChart
+              buckets={result.buckets}
+              responses={result.responses}
+              multi={result.type === "multiple_choice"}
+            />
+          )}
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/lib/survey/results.ts
+++ b/lib/survey/results.ts
@@ -1,0 +1,158 @@
+// Survey results aggregation (issue #79).
+//
+// The seam between raw `survey_responses` rows and the results chart shown
+// in state 5 of /survey. The chart consumes pre-aggregated shapes; this
+// module is the only place that knows how answers are stored. When real fan
+// responses start flowing (after #44 ships the survey builder + #41's anon
+// submit), the aggregation layer is unchanged — only the row count grows.
+//
+// Answer storage shape (matches the form output in components/survey/SurveyForm
+// and the seed):
+//   single_choice  → answers[questionId] = "<option>"
+//   multiple_choice → answers[questionId] = ["<opt>", ...]
+//   ranking        → answers[questionId] = ["<option>", ...] best-first
+//
+// For ranking we reuse Borda from lib/reveal/aggregate.ts so all reveal-
+// adjacent math has one home.
+
+import { bordaStrategy } from "@/lib/reveal/aggregate";
+import type { SurveyQuestion } from "./source";
+
+export type ChoiceBucket = {
+  option: string;
+  count: number;
+  /** % of total responses for this question. */
+  share: number;
+};
+
+export type RankingBucket = {
+  option: string;
+  /** Borda points (higher = better). */
+  score: number;
+  /** 1-indexed rank by score. */
+  rank: number;
+  /** Average submitted position (1-indexed). */
+  averagePosition: number;
+  /** Number of submissions that included this contestant. */
+  appearances: number;
+};
+
+export type QuestionResults =
+  | { type: "single_choice"; question: SurveyQuestion; responses: number; buckets: ChoiceBucket[] }
+  | { type: "multiple_choice"; question: SurveyQuestion; responses: number; buckets: ChoiceBucket[] }
+  | { type: "ranking"; question: SurveyQuestion; responses: number; buckets: RankingBucket[] };
+
+type AnswersMap = Record<string, unknown>;
+
+/**
+ * Aggregate a batch of `survey_responses.answers` into per-question results.
+ * Pure: no DB access, no side effects. Pass the canonical question list (so
+ * we know the type + option set) plus the array of answers blobs.
+ */
+export function aggregateResponses(
+  questions: SurveyQuestion[],
+  answersList: AnswersMap[],
+): QuestionResults[] {
+  return questions.map((question) => aggregateOne(question, answersList));
+}
+
+function aggregateOne(question: SurveyQuestion, answersList: AnswersMap[]): QuestionResults {
+  if (question.type === "ranking") {
+    return aggregateRanking(question, answersList);
+  }
+  return aggregateChoice(question, answersList);
+}
+
+function aggregateChoice(
+  question: SurveyQuestion,
+  answersList: AnswersMap[],
+): QuestionResults {
+  const counts = new Map<string, number>();
+  // Pre-seed every known option to 0 so the chart can show every choice even
+  // if some got no votes.
+  for (const option of question.options) counts.set(option, 0);
+
+  let responseCount = 0;
+  for (const answers of answersList) {
+    const raw = answers[question.id];
+    if (raw === undefined || raw === null) continue;
+    responseCount += 1;
+    if (Array.isArray(raw)) {
+      // multiple_choice — each selected option contributes one.
+      for (const item of raw) {
+        if (typeof item === "string") {
+          counts.set(item, (counts.get(item) ?? 0) + 1);
+        }
+      }
+    } else if (typeof raw === "string") {
+      counts.set(raw, (counts.get(raw) ?? 0) + 1);
+    }
+  }
+
+  // For single_choice the denominator is response count.
+  // For multiple_choice each respondent contributes N picks; share is still
+  // relative to response count (so 100% means everyone picked this option),
+  // which is the convention the chart wants.
+  const buckets: ChoiceBucket[] = [...counts.entries()]
+    .map(([option, count]) => ({
+      option,
+      count,
+      share: responseCount > 0 ? count / responseCount : 0,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  return {
+    type: question.type as "single_choice" | "multiple_choice",
+    question,
+    responses: responseCount,
+    buckets,
+  };
+}
+
+function aggregateRanking(
+  question: SurveyQuestion,
+  answersList: AnswersMap[],
+): QuestionResults {
+  // Pull out valid ranking arrays and feed them into Borda.
+  const submissions: { order: string[] }[] = [];
+  for (const answers of answersList) {
+    const raw = answers[question.id];
+    if (!Array.isArray(raw)) continue;
+    const order = raw.filter((item): item is string => typeof item === "string");
+    if (order.length > 0) submissions.push({ order });
+  }
+
+  const responses = submissions.length;
+  if (responses === 0) {
+    return { type: "ranking", question, responses, buckets: [] };
+  }
+
+  // Borda scores.
+  const bordaScores = bordaStrategy(submissions);
+  // Average position + appearance count — companion stats Borda alone doesn't tell.
+  const positionTotals = new Map<string, number>();
+  const appearances = new Map<string, number>();
+  for (const { order } of submissions) {
+    order.forEach((option, index) => {
+      positionTotals.set(option, (positionTotals.get(option) ?? 0) + (index + 1));
+      appearances.set(option, (appearances.get(option) ?? 0) + 1);
+    });
+  }
+
+  const buckets: RankingBucket[] = [...bordaScores.entries()]
+    .map(([option, score]) => {
+      const seen = appearances.get(option) ?? 0;
+      const positionSum = positionTotals.get(option) ?? 0;
+      return {
+        option,
+        score,
+        rank: 0, // assigned below after sort
+        averagePosition: seen > 0 ? positionSum / seen : 0,
+        appearances: seen,
+      };
+    })
+    .sort((a, b) => b.score - a.score)
+    .map((bucket, index) => ({ ...bucket, rank: index + 1 }));
+
+  return { type: "ranking", question, responses, buckets };
+}

--- a/lib/survey/source.ts
+++ b/lib/survey/source.ts
@@ -8,6 +8,8 @@
 // survey-open and the user's load is simply absent).
 
 import { createClient } from "@/lib/supabase/server";
+import { serviceClient } from "@/lib/supabase/service";
+import { aggregateResponses, type QuestionResults } from "./results";
 
 export type QuestionType = "ranking" | "multiple_choice" | "single_choice";
 
@@ -52,6 +54,7 @@ export type SurveyPageState =
       survey: SurveyMeta;
       questions: SurveyQuestion[];
       answers: Record<string, unknown> | null;
+      results: QuestionResults[];
     };
 
 type SurveyRow = {
@@ -176,7 +179,18 @@ export async function getSurveyPageState(userId: string): Promise<SurveyPageStat
     return { kind: "closed-pending", survey: meta, questions, answers };
   }
   if (survey.status === "results_published") {
-    return { kind: "results-published", survey: meta, questions, answers };
+    // Aggregate every response (incl. anonymous) into per-question results.
+    // Service client because survey_responses RLS limits each user to their
+    // own row — but published results are a community view, by definition.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: allRows } = await (serviceClient.from("survey_responses") as any)
+      .select("answers")
+      .eq("survey_id", survey.id);
+    const answersList = ((allRows as { answers: Record<string, unknown> }[] | null) ?? []).map(
+      (row) => row.answers,
+    );
+    const results = aggregateResponses(questions, answersList);
+    return { kind: "results-published", survey: meta, questions, answers, results };
   }
   return { kind: "no-active" }; // draft — treat as none
 }

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -251,59 +251,120 @@ INSERT INTO surveys (id, season_id, title, week_number, status, closes_at, publi
 -- SURVEY QUESTIONS
 -- ============================================================
 
+-- Question UUIDs are pinned explicitly so seed responses can reference them.
+-- (The form keys answers by question.id; the seed mirrors that.)
+
 -- Week 3 (active)
-INSERT INTO survey_questions (survey_id, text, type, display_order, options, uses_contestants) VALUES
-  ('00000005-0000-0000-0000-000000000002',
+INSERT INTO survey_questions (id, survey_id, text, type, display_order, options, uses_contestants) VALUES
+  ('00000006-0000-0000-0000-000000000301', '00000005-0000-0000-0000-000000000002',
    'Rank the houseguests from best to worst game this week.',
    'ranking', 1, null, true),
 
-  ('00000005-0000-0000-0000-000000000002',
+  ('00000006-0000-0000-0000-000000000302', '00000005-0000-0000-0000-000000000002',
    'Which competition did you enjoy watching most?',
    'single_choice', 2,
    '["HOH Competition", "Veto Competition", "Have-Not Competition"]', false);
 
--- Week 1 (results_published)
-INSERT INTO survey_questions (survey_id, text, type, display_order, options, uses_contestants) VALUES
-  ('00000005-0000-0000-0000-000000000004',
+-- Week 1 (results_published) — exercises all three chart types in #79.
+INSERT INTO survey_questions (id, survey_id, text, type, display_order, options, uses_contestants) VALUES
+  ('00000006-0000-0000-0000-000000000101', '00000005-0000-0000-0000-000000000004',
    'Who was your favourite houseguest based on first impressions?',
    'single_choice', 1, null, true),
 
-  ('00000005-0000-0000-0000-000000000004',
+  ('00000006-0000-0000-0000-000000000102', '00000005-0000-0000-0000-000000000004',
    'How do you feel about the cast overall?',
    'single_choice', 2,
-   '["Love it", "It''s okay", "Disappointed"]', false);
+   '["Love it", "It''s okay", "Disappointed"]', false),
+
+  ('00000006-0000-0000-0000-000000000103', '00000005-0000-0000-0000-000000000004',
+   'What stands out about this cast? (Pick all that apply)',
+   'multiple_choice', 3,
+   '["Strategy", "Drama", "Comp threats", "Underdogs", "Returning players"]', false),
+
+  ('00000006-0000-0000-0000-000000000104', '00000005-0000-0000-0000-000000000004',
+   'Rank your top picks to win.',
+   'ranking', 4, null, true);
 
 
 -- ============================================================
 -- SURVEY RESPONSES
+--
+-- Answers are keyed by question UUID — matches what the form produces.
+-- Contestant references use the FULL name from `contestants.name` so
+-- aggregation lines up cleanly with form-submitted responses.
 -- ============================================================
 
 -- Week 3 active survey: two logged-in responses
 INSERT INTO survey_responses (survey_id, user_id, answers, is_anonymous, submitted_at) VALUES
   ('00000005-0000-0000-0000-000000000002', 'bbbbbbbb-0000-0000-0000-000000000002',
-   '{"1":["Janelle","Ian","Tyler","Angela","Nicole A","Memphis","Kaysar","Da''Vonne","Derek","Enzo"],"2":"HOH Competition"}',
+   '{
+     "00000006-0000-0000-0000-000000000301": ["Janelle Pierzina","Ian Terry","Tyler Crispen","Angela Rummans","Nicole Anthony","Memphis Garrett","Kaysar Ridha","Da''Vonne Rogers","Derek Xiao"],
+     "00000006-0000-0000-0000-000000000302": "HOH Competition"
+   }',
    false, now() - interval '2 hours'),
 
   ('00000005-0000-0000-0000-000000000002', 'cccccccc-0000-0000-0000-000000000003',
-   '{"1":["Angela","Tyler","Ian","Janelle","Nicole A","Memphis","Derek","Kaysar","Da''Vonne","Enzo"],"2":"Veto Competition"}',
+   '{
+     "00000006-0000-0000-0000-000000000301": ["Angela Rummans","Tyler Crispen","Ian Terry","Janelle Pierzina","Nicole Anthony","Memphis Garrett","Derek Xiao","Kaysar Ridha","Da''Vonne Rogers"],
+     "00000006-0000-0000-0000-000000000302": "Veto Competition"
+   }',
    false, now() - interval '1 hour');
 
--- Week 1 results-published survey: three logged-in + one anonymous
+-- Week 1 results-published survey: six responses (five logged-in / mock + one anonymous).
+-- Hand-tuned for variety so all three chart types show non-trivial aggregation.
 INSERT INTO survey_responses (survey_id, user_id, answers, is_anonymous, submitted_at) VALUES
   ('00000005-0000-0000-0000-000000000004', 'bbbbbbbb-0000-0000-0000-000000000002',
-   '{"1":"Janelle","2":"Love it"}',
+   '{
+     "00000006-0000-0000-0000-000000000101": "Janelle Pierzina",
+     "00000006-0000-0000-0000-000000000102": "Love it",
+     "00000006-0000-0000-0000-000000000103": ["Returning players","Strategy","Drama"],
+     "00000006-0000-0000-0000-000000000104": ["Janelle Pierzina","Ian Terry","Angela Rummans","Tyler Crispen","Nicole Anthony"]
+   }',
    false, now() - interval '16 days'),
 
   ('00000005-0000-0000-0000-000000000004', 'cccccccc-0000-0000-0000-000000000003',
-   '{"1":"Angela","2":"Love it"}',
+   '{
+     "00000006-0000-0000-0000-000000000101": "Angela Rummans",
+     "00000006-0000-0000-0000-000000000102": "Love it",
+     "00000006-0000-0000-0000-000000000103": ["Strategy","Comp threats"],
+     "00000006-0000-0000-0000-000000000104": ["Angela Rummans","Tyler Crispen","Ian Terry","Janelle Pierzina","Memphis Garrett"]
+   }',
    false, now() - interval '15 days'),
 
   ('00000005-0000-0000-0000-000000000004', 'dddddddd-0000-0000-0000-000000000004',
-   '{"1":"Janelle","2":"It''s okay"}',
+   '{
+     "00000006-0000-0000-0000-000000000101": "Janelle Pierzina",
+     "00000006-0000-0000-0000-000000000102": "It''s okay",
+     "00000006-0000-0000-0000-000000000103": ["Returning players","Drama"],
+     "00000006-0000-0000-0000-000000000104": ["Janelle Pierzina","Angela Rummans","Ian Terry","Tyler Crispen","Memphis Garrett"]
+   }',
    false, now() - interval '15 days'),
 
+  ('00000005-0000-0000-0000-000000000004', 'eeeeeeee-0000-0000-0000-000000000005',
+   '{
+     "00000006-0000-0000-0000-000000000101": "Tyler Crispen",
+     "00000006-0000-0000-0000-000000000102": "Love it",
+     "00000006-0000-0000-0000-000000000103": ["Underdogs","Comp threats","Drama"],
+     "00000006-0000-0000-0000-000000000104": ["Tyler Crispen","Janelle Pierzina","Ian Terry","Angela Rummans","Nicole Anthony"]
+   }',
+   false, now() - interval '14 days'),
+
+  ('00000005-0000-0000-0000-000000000004', 'aaaaaaaa-0000-0000-0000-000000000001',
+   '{
+     "00000006-0000-0000-0000-000000000101": "Ian Terry",
+     "00000006-0000-0000-0000-000000000102": "Love it",
+     "00000006-0000-0000-0000-000000000103": ["Strategy","Returning players"],
+     "00000006-0000-0000-0000-000000000104": ["Ian Terry","Janelle Pierzina","Angela Rummans","Memphis Garrett","Tyler Crispen"]
+   }',
+   false, now() - interval '13 days'),
+
   ('00000005-0000-0000-0000-000000000004', null,
-   '{"1":"Ian","2":"Love it"}',
+   '{
+     "00000006-0000-0000-0000-000000000101": "Ian Terry",
+     "00000006-0000-0000-0000-000000000102": "Love it",
+     "00000006-0000-0000-0000-000000000103": ["Strategy","Comp threats","Underdogs"],
+     "00000006-0000-0000-0000-000000000104": ["Ian Terry","Tyler Crispen","Angela Rummans","Janelle Pierzina","Kaysar Ridha"]
+   }',
    true, now() - interval '14 days');
 
 


### PR DESCRIPTION
Closes #79. Replaces the "chart coming soon" stub on `/survey` with real charts for all three question types, aggregated from `survey_responses`. Built behind a data seam, so when survey builder (#44) lands and real fans submit, **nothing here changes** — the row count just grows.

## Architecture (the seam that makes this work without the survey builder)

```
SurveyView state 5 ─→ lib/survey/source.ts ─→ aggregateResponses() ─→ survey_responses (DB)
                                                    │
                                                    ↓ pure functions per question type
                                                    ↓ ranking → bordaStrategy() from lib/reveal/aggregate.ts
                                                ResultsView ─→ BarChart / RankingResults
```

The chart components consume pre-aggregated shapes (`ChoiceBucket[]` / `RankingBucket[]`). The aggregation knows nothing about the UI. Adding more responses, more surveys, more question variants — the chart layer doesn't change.

## What's in
- **`lib/survey/results.ts`** — pure aggregation
  - `single_choice` / `multiple_choice`: count per option + share. Pre-seeds every option to 0 so the chart shows the full choice space even when some got no votes.
  - `ranking`: Borda points (from `lib/reveal/aggregate.ts` — keeps reveal-adjacent math in one home) plus avg-position + appearance count as companion stats.
- **`components/survey/results/`** — chart components
  - `BarChart.tsx` — shared single/multiple. Highlights top option in bright sky; rest in dimmer sky.
  - `RankingResults.tsx` — Borda bars with avg-position. Top rank in emerald, rest dimmer.
  - `ResultsView.tsx` — orchestrator, one card per question.
- **`lib/survey/source.ts`** — extends `results-published` state with a `results` field; fetches all responses via service client (published results are a community view; owners-only RLS doesn't apply here by design) and aggregates server-side.
- **`components/survey/SurveyView.tsx`** — state 5 renders `ResultsView` above the existing "Your picks" section.
- **`supabase/seed.sql`** — enriched week 1 (already `results_published`):
  - Added a `multiple_choice` question ("What stands out about this cast?")
  - Added a `ranking` question ("Rank your top picks to win")
  - 6 hand-tuned responses (5 logged-in + 1 anonymous) so each chart type shows meaningful aggregation immediately
  - Fixed two latent issues: question UUIDs now explicit (responses can reference them — matches what the form produces); contestant references use full names (matches `contestants.name`)

## Visual design — intentionally restrained
The chart styling is meant to be **iterated**, not finalized by me. Comments in `BarChart.tsx` and `RankingResults.tsx` flag the presentation block as "fair game to redesign." The aggregation layer, prop contracts, and Layout are what stay stable.

## Verified
- ✅ `pnpm typecheck` clean
- ✅ `pnpm build` clean (`/survey` registered)
- ✅ End-to-end in preview: logged in, surfaced week 1, all four charts render with seed-aggregated data. Math sanity-checks: ranking q has Ian Terry at 23 Borda points; 6 responses × 5-position list ⇒ max 30, his avg position 2.2 ⇒ `6 × (5 − 1.2)` = 22.8 ≈ 23 ✓. Screenshot in PR comments.

## Note: no survey builder needed yet
This PR is the path forward you asked about — chart references real survey data through the seam, with seed data filling in for what real submissions will eventually produce. When #44 lands (admin can create surveys), the only thing changing is who creates the rows in `survey_questions` / `survey_responses`. The charts read them either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)