### PR TITLE
feat: admin contestant management page (#43)

### DIFF
--- a/app/admin/contestants/page.tsx
+++ b/app/admin/contestants/page.tsx
@@ -1,0 +1,113 @@
+// Admin contestants page (issue #43).
+//
+// Lists every contestant for the active season with an inline edit affordance.
+// Admin-gated by app/admin/layout.tsx (requireAdmin). Server-rendered + force-
+// dynamic since contestant state changes per-request (status flips, flag
+// toggles).
+
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import {
+  ContestantTable,
+  type AdminContestant,
+} from "@/components/admin/ContestantTable";
+import type { ContestantStatus } from "@/lib/admin/contestants";
+
+export const dynamic = "force-dynamic";
+
+type ContestantRow = {
+  id: string;
+  name: string;
+  photo_url: string | null;
+  bio: string | null;
+  status: ContestantStatus;
+  is_hoh: boolean;
+  is_nominated: boolean;
+  has_veto: boolean;
+  total_shares_outstanding: string;
+};
+
+export default async function AdminContestantsPage() {
+  const supabase = await createClient();
+
+  // Active season — there's only one at a time (enforced by partial unique index).
+  const { data: seasonRow } = await supabase
+    .from("seasons")
+    .select("id, name")
+    .eq("status", "active")
+    .maybeSingle();
+  const season = seasonRow as { id: string; name: string } | null;
+
+  if (!season) {
+    return (
+      <Shell title="Contestants">
+        <p className="text-sm text-neutral-400">
+          No active season. Create one to manage contestants.
+        </p>
+      </Shell>
+    );
+  }
+
+  const { data } = await supabase
+    .from("contestants")
+    .select(
+      "id, name, photo_url, bio, status, is_hoh, is_nominated, has_veto, total_shares_outstanding",
+    )
+    .eq("season_id", season.id)
+    .order("name");
+  const rows = (data as ContestantRow[] | null) ?? [];
+
+  const contestants: AdminContestant[] = rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    photoUrl: row.photo_url,
+    bio: row.bio,
+    status: row.status,
+    isHoh: row.is_hoh,
+    isNominated: row.is_nominated,
+    hasVeto: row.has_veto,
+    totalSharesOutstanding: parseFloat(row.total_shares_outstanding),
+  }));
+
+  return (
+    <Shell title="Contestants" subtitle={season.name}>
+      {contestants.length === 0 ? (
+        <p className="text-sm text-neutral-400">
+          No contestants yet for this season.
+        </p>
+      ) : (
+        <ContestantTable contestants={contestants} />
+      )}
+    </Shell>
+  );
+}
+
+function Shell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <Link
+            href="/admin"
+            className="text-xs font-semibold uppercase tracking-widest text-neutral-500 hover:text-neutral-300"
+          >
+            ← Admin
+          </Link>
+          <h1 className="mt-1 text-2xl font-black tracking-tight text-neutral-100">
+            {title}
+          </h1>
+          {subtitle && <p className="mt-1 text-sm text-neutral-400">{subtitle}</p>}
+        </div>
+      </header>
+      {children}
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -14,6 +14,17 @@ export default function AdminHomePage() {
       <ul className="mt-6 space-y-3 text-sm">
         <li>
           <Link
+            href="/admin/contestants"
+            className="block rounded-lg border border-neutral-200 bg-white p-4 hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-900"
+          >
+            <span className="block font-semibold">Contestants</span>
+            <span className="mt-1 block text-neutral-500">
+              Edit names / photos / bios, set status, toggle HoH / Nominated / Veto.
+            </span>
+          </Link>
+        </li>
+        <li>
+          <Link
             href="/admin/reveal"
             className="block rounded-lg border border-neutral-200 bg-white p-4 hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-900"
           >

--- a/components/admin/ContestantTable.tsx
+++ b/components/admin/ContestantTable.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+// Admin contestant management table (issue #43).
+//
+// One row per contestant for the active season. Click a row to expand inline
+// for editing — no modal. The collapsed row shows the at-a-glance state
+// (photo, name, status, visual flags, supply for monitoring); the expanded
+// form lets the admin change name/photo/bio/status and toggle the three
+// visual flags. HoH single-occupant enforcement is in the server action.
+
+import { useState, useTransition } from "react";
+import {
+  setContestantFlag,
+  updateContestant,
+  type ContestantFlag,
+  type ContestantStatus,
+} from "@/lib/admin/contestants";
+
+export type AdminContestant = {
+  id: string;
+  name: string;
+  photoUrl: string | null;
+  bio: string | null;
+  status: ContestantStatus;
+  isHoh: boolean;
+  isNominated: boolean;
+  hasVeto: boolean;
+  totalSharesOutstanding: number;
+};
+
+type Props = { contestants: AdminContestant[] };
+
+const STATUS_LABELS: Record<ContestantStatus, string> = {
+  active: "Active",
+  evicted: "Evicted",
+  winner: "Winner",
+  runner_up: "Runner-up",
+};
+
+const STATUS_CLASSES: Record<ContestantStatus, string> = {
+  active: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+  evicted: "bg-rose-500/15 text-rose-300 border-rose-500/30",
+  winner: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+  runner_up: "bg-sky-500/15 text-sky-300 border-sky-500/30",
+};
+
+const FLAG_LABELS: Record<ContestantFlag, string> = {
+  is_hoh: "HoH",
+  is_nominated: "Nominated",
+  has_veto: "Veto",
+};
+
+export function ContestantTable({ contestants }: Props) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {contestants.map((contestant) => {
+        const isOpen = expanded === contestant.id;
+        return (
+          <li
+            key={contestant.id}
+            className="overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02]"
+          >
+            <button
+              type="button"
+              onClick={() => setExpanded(isOpen ? null : contestant.id)}
+              className="grid w-full grid-cols-[48px_1fr_auto_auto] items-center gap-4 p-3 text-left hover:bg-white/[0.03]"
+            >
+              <span className="grid h-12 w-12 place-items-center overflow-hidden rounded-full border border-white/10 bg-neutral-900">
+                {contestant.photoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={contestant.photoUrl}
+                    alt=""
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <span className="text-xs text-neutral-500">—</span>
+                )}
+              </span>
+              <span>
+                <span className="block text-base font-semibold text-neutral-100">
+                  {contestant.name}
+                </span>
+                <span className="mt-0.5 flex flex-wrap gap-1.5 text-xs">
+                  {contestant.isHoh && (
+                    <Badge color="bg-amber-500/20 text-amber-200 border-amber-500/30">
+                      👑 HoH
+                    </Badge>
+                  )}
+                  {contestant.isNominated && (
+                    <Badge color="bg-rose-500/20 text-rose-200 border-rose-500/30">
+                      🎯 Nominated
+                    </Badge>
+                  )}
+                  {contestant.hasVeto && (
+                    <Badge color="bg-violet-500/20 text-violet-200 border-violet-500/30">
+                      🛡 Veto
+                    </Badge>
+                  )}
+                </span>
+              </span>
+              <span
+                className={`rounded-full border px-2.5 py-0.5 text-xs font-semibold ${STATUS_CLASSES[contestant.status]}`}
+              >
+                {STATUS_LABELS[contestant.status]}
+              </span>
+              <span className="hidden text-right text-xs text-neutral-500 sm:block">
+                <span className="tabular-nums">
+                  {Math.round(contestant.totalSharesOutstanding)}
+                </span>{" "}
+                shares
+              </span>
+            </button>
+            {isOpen && (
+              <ContestantEditForm
+                contestant={contestant}
+                onClose={() => setExpanded(null)}
+              />
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function Badge({ children, color }: { children: React.ReactNode; color: string }) {
+  return (
+    <span className={`rounded-full border px-2 py-0.5 ${color}`}>{children}</span>
+  );
+}
+
+function ContestantEditForm({
+  contestant,
+  onClose,
+}: {
+  contestant: AdminContestant;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState(contestant.name);
+  const [photoUrl, setPhotoUrl] = useState(contestant.photoUrl ?? "");
+  const [bio, setBio] = useState(contestant.bio ?? "");
+  const [status, setStatus] = useState<ContestantStatus>(contestant.status);
+  const [error, setError] = useState<string | null>(null);
+  const [savingPending, startSaving] = useTransition();
+  const [flagPending, startFlag] = useTransition();
+
+  const dirty =
+    name !== contestant.name ||
+    photoUrl !== (contestant.photoUrl ?? "") ||
+    bio !== (contestant.bio ?? "") ||
+    status !== contestant.status;
+
+  return (
+    <div className="border-t border-white/10 bg-black/30 p-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="text-sm">
+          <span className="mb-1 block text-xs font-semibold text-neutral-400">
+            Name
+          </span>
+          <input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-neutral-100"
+          />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block text-xs font-semibold text-neutral-400">
+            Photo URL
+          </span>
+          <input
+            value={photoUrl}
+            onChange={(event) => setPhotoUrl(event.target.value)}
+            placeholder="https://…"
+            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-neutral-100"
+          />
+        </label>
+        <label className="text-sm sm:col-span-2">
+          <span className="mb-1 block text-xs font-semibold text-neutral-400">
+            Bio
+          </span>
+          <textarea
+            value={bio}
+            onChange={(event) => setBio(event.target.value)}
+            rows={2}
+            className="w-full resize-none rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-neutral-100"
+          />
+        </label>
+        <fieldset className="text-sm sm:col-span-2">
+          <legend className="mb-1 block text-xs font-semibold text-neutral-400">
+            Status
+          </legend>
+          <div className="flex flex-wrap gap-2">
+            {(Object.keys(STATUS_LABELS) as ContestantStatus[]).map((option) => (
+              <label
+                key={option}
+                className={`cursor-pointer rounded-full border px-3 py-1 text-xs font-semibold ${
+                  status === option
+                    ? STATUS_CLASSES[option]
+                    : "border-white/10 bg-white/[0.02] text-neutral-400 hover:bg-white/[0.05]"
+                }`}
+              >
+                <input
+                  type="radio"
+                  name={`status-${contestant.id}`}
+                  value={option}
+                  checked={status === option}
+                  onChange={() => setStatus(option)}
+                  className="sr-only"
+                />
+                {STATUS_LABELS[option]}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+        <fieldset className="text-sm sm:col-span-2">
+          <legend className="mb-1 block text-xs font-semibold text-neutral-400">
+            Visual flags
+          </legend>
+          <div className="flex flex-wrap gap-2">
+            <FlagToggle
+              label="👑 HoH"
+              active={contestant.isHoh}
+              disabled={flagPending}
+              onToggle={(value) => {
+                startFlag(async () => {
+                  const result = await setContestantFlag(contestant.id, "is_hoh", value);
+                  if (!result.ok) setError(result.error);
+                });
+              }}
+            />
+            <FlagToggle
+              label="🎯 Nominated"
+              active={contestant.isNominated}
+              disabled={flagPending}
+              onToggle={(value) => {
+                startFlag(async () => {
+                  const result = await setContestantFlag(
+                    contestant.id,
+                    "is_nominated",
+                    value,
+                  );
+                  if (!result.ok) setError(result.error);
+                });
+              }}
+            />
+            <FlagToggle
+              label="🛡 Veto"
+              active={contestant.hasVeto}
+              disabled={flagPending}
+              onToggle={(value) => {
+                startFlag(async () => {
+                  const result = await setContestantFlag(contestant.id, "has_veto", value);
+                  if (!result.ok) setError(result.error);
+                });
+              }}
+            />
+          </div>
+          <p className="mt-2 text-xs text-neutral-500">
+            HoH is single-occupant — toggling it on for this contestant clears it
+            elsewhere in the same season.
+          </p>
+        </fieldset>
+      </div>
+
+      {error && (
+        <p className="mt-3 rounded-lg border border-rose-500/30 bg-rose-500/10 p-2 text-sm text-rose-200">
+          {error}
+        </p>
+      )}
+
+      <div className="mt-4 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-lg border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-neutral-300 hover:bg-white/[0.08]"
+        >
+          Close
+        </button>
+        <button
+          type="button"
+          disabled={savingPending || !dirty}
+          onClick={() => {
+            setError(null);
+            startSaving(async () => {
+              const result = await updateContestant(contestant.id, {
+                name,
+                photo_url: photoUrl.trim() ? photoUrl.trim() : null,
+                bio: bio.trim() ? bio.trim() : null,
+                status,
+              });
+              if (!result.ok) setError(result.error);
+            });
+          }}
+          className="rounded-lg bg-sky-500 px-4 py-1.5 text-xs font-bold uppercase tracking-wider text-white shadow-lg shadow-sky-500/30 hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-neutral-700 disabled:text-neutral-400 disabled:shadow-none"
+        >
+          {savingPending ? "Saving…" : "Save changes"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function FlagToggle({
+  label,
+  active,
+  disabled,
+  onToggle,
+}: {
+  label: string;
+  active: boolean;
+  disabled: boolean;
+  onToggle: (value: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onToggle(!active)}
+      className={`rounded-full border px-3 py-1 text-xs font-semibold transition disabled:opacity-50 ${
+        active
+          ? "border-amber-500/30 bg-amber-500/20 text-amber-200"
+          : "border-white/10 bg-white/[0.02] text-neutral-400 hover:bg-white/[0.05]"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/lib/admin/contestants.ts
+++ b/lib/admin/contestants.ts
@@ -1,0 +1,83 @@
+"use server";
+
+// Admin contestant management server actions (issue #43).
+//
+// `contestants` already has admin-write RLS (see migration 0001), so writes
+// flow through the user-scoped server client and the policy gates them. No
+// service-role escalation needed.
+//
+// One business rule is enforced here rather than at the DB layer (per the
+// design doc: "only one HoH at a time — enforce in UI, not DB"): toggling
+// is_hoh ON for a contestant clears it from every other contestant in the
+// same season. is_nominated and has_veto are plain per-row toggles.
+//
+// revalidatePath() pings the admin contestants route so the server re-renders
+// after a mutation without the client needing to refetch manually.
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+export type ContestantStatus = "active" | "evicted" | "winner" | "runner_up";
+export type ContestantFlag = "is_hoh" | "is_nominated" | "has_veto";
+
+export type UpdateResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export async function updateContestant(
+  id: string,
+  fields: {
+    name?: string;
+    photo_url?: string | null;
+    bio?: string | null;
+    status?: ContestantStatus;
+  },
+): Promise<UpdateResult> {
+  if (Object.keys(fields).length === 0) return { ok: true };
+
+  const supabase = await createClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase.from("contestants") as any)
+    .update(fields)
+    .eq("id", id);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/admin/contestants");
+  return { ok: true };
+}
+
+export async function setContestantFlag(
+  id: string,
+  flag: ContestantFlag,
+  value: boolean,
+): Promise<UpdateResult> {
+  const supabase = await createClient();
+
+  // HoH is the only flag with a single-occupant rule. When turning it ON,
+  // clear it from every other contestant in the same season first.
+  if (flag === "is_hoh" && value) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: seasonRow } = await (supabase.from("contestants") as any)
+      .select("season_id")
+      .eq("id", id)
+      .maybeSingle();
+    const seasonId = (seasonRow as { season_id: string } | null)?.season_id;
+    if (seasonId) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error: clearError } = await (supabase.from("contestants") as any)
+        .update({ is_hoh: false })
+        .eq("season_id", seasonId)
+        .neq("id", id);
+      if (clearError) return { ok: false, error: clearError.message };
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase.from("contestants") as any)
+    .update({ [flag]: value })
+    .eq("id", id);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/admin/contestants");
+  return { ok: true };
+}


### PR DESCRIPTION
Closes #43. First Phase 4 admin surface — admins can edit contestant info, change status, and toggle visual flags throughout the season. Establishes the admin CRUD pattern that #44 (survey builder) and #42 (season setup) will inherit.

## What's here
- **`lib/admin/contestants.ts`** — server actions:
  - `updateContestant(id, fields)` — name, photo_url, bio, status
  - `setContestantFlag(id, flag, value)` — is_hoh / is_nominated / has_veto
  - **HoH single-occupant rule** enforced here per the design doc ("enforce in UI, not DB"): turning is_hoh ON for a contestant clears it from every other contestant in the same season first.
  - RLS already gates admin writes (existing `contestants: admin write` policy); no service-role escalation needed.
  - `revalidatePath("/admin/contestants")` after each write so the server re-renders.
- **`components/admin/ContestantTable.tsx`** — collapsible list. Row shows photo / name / visual-flag badges / status / supply for at-a-glance monitoring. Click to expand inline (no modal) into an edit form with name, photo URL, bio, 4-way status radio, three flag toggles.
- **`app/admin/contestants/page.tsx`** — server shell, `force-dynamic` (contestant state changes per request), loads active season's contestants alphabetically.
- **`app/admin/page.tsx`** — added "Contestants" link to admin home above the reveal console.

## Verified end-to-end (local seed)
- ✅ Page renders all 10 contestants with seed flags (Kaysar HoH, Memphis Nominated, Ian Veto) and statuses (Enzo Evicted; rest Active). Screenshot in PR comments.
- ✅ Expanded Janelle's row, clicked HoH toggle → DB shows Janelle as the only HoH, Kaysar's flag cleared automatically (single-occupant rule firing correctly).
- ✅ Set Janelle status=winner via form → reflected in DB.
- ✅ `pnpm typecheck`, `pnpm test` (11 pass), `pnpm build` clean

## Out of scope (called out for follow-ups, not blockers)
- **Recent trade activity column** (#43 lists it as a "monitor" task). Skipped for v1 to keep the list tight; can add a join to `trades` + a "Last trade: 2h ago" column when the admin actually needs it.
- **Photo upload** — currently the form takes a photo URL. Drag-and-drop upload would belong with #42's AI import work (both need Storage wiring).

## What's next in Phase 4
- **#44** survey builder (next PR — reuses this admin pattern + the question-type components from #41)
- **#42** season setup, with AI contestant import deferred to a separate issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)