### PR TITLE
feat: season management — status transitions + pricing lock + results function (#42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ See `docs/tech-stack.md` for full decisions and rationale.
 | `docs/design/interaction-flow-*.md` | Breadboarded user flows |
 | `docs/dev-environment.md` | Environment setup, migration workflow, fake season |
 | `docs/migrations.md` | How schema changes ship (CLI `db push` only) + drift-recovery runbook — read before applying any migration |
+| `docs/admin-recipes.md` | Claude-orchestrated admin ops (bootstrap a new season from a URL, publish season results, etc.) — read when the user asks to "set up BB28" or similar |
 
 ---
 

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -14,6 +14,17 @@ export default function AdminHomePage() {
       <ul className="mt-6 space-y-3 text-sm">
         <li>
           <Link
+            href="/admin/seasons"
+            className="block rounded-lg border border-neutral-200 bg-white p-4 hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-900"
+          >
+            <span className="block font-semibold">Seasons</span>
+            <span className="mt-1 block text-neutral-500">
+              Drive status transitions: setup → pre-season → active → ended → results published.
+            </span>
+          </Link>
+        </li>
+        <li>
+          <Link
             href="/admin/contestants"
             className="block rounded-lg border border-neutral-200 bg-white p-4 hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-900"
           >

--- a/app/admin/seasons/[id]/page.tsx
+++ b/app/admin/seasons/[id]/page.tsx
@@ -1,0 +1,66 @@
+// Admin season detail (issue #42). Server shell loads the season + hands
+// off to the SeasonDetail client component, which renders the editable form
+// + status-transition console.
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { SeasonDetail, type AdminSeason } from "@/components/admin/SeasonDetail";
+import type { SeasonStatus } from "@/lib/admin/season-types";
+
+export const dynamic = "force-dynamic";
+
+type SeasonRow = {
+  id: string;
+  name: string;
+  status: SeasonStatus;
+  start_date: string | null;
+  end_date: string | null;
+  starting_balance: string;
+  k_constant: string;
+  base_price: string;
+};
+
+type PageProps = { params: Promise<{ id: string }> };
+
+export default async function AdminSeasonDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("seasons")
+    .select(
+      "id, name, status, start_date, end_date, starting_balance, k_constant, base_price",
+    )
+    .eq("id", id)
+    .maybeSingle();
+  const row = data as SeasonRow | null;
+  if (!row) notFound();
+
+  const season: AdminSeason = {
+    id: row.id,
+    name: row.name,
+    status: row.status,
+    startDate: row.start_date,
+    endDate: row.end_date,
+    startingBalance: parseFloat(row.starting_balance),
+    kConstant: parseFloat(row.k_constant),
+    basePrice: parseFloat(row.base_price),
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <header className="mb-6">
+        <Link
+          href="/admin/seasons"
+          className="text-xs font-semibold uppercase tracking-widest text-neutral-500 hover:text-neutral-300"
+        >
+          ← Seasons
+        </Link>
+        <h1 className="mt-1 text-2xl font-black tracking-tight text-neutral-100">
+          {season.name}
+        </h1>
+      </header>
+      <SeasonDetail season={season} />
+    </div>
+  );
+}

--- a/app/admin/seasons/page.tsx
+++ b/app/admin/seasons/page.tsx
@@ -1,0 +1,107 @@
+// Admin seasons list (issue #42). No "create new season" button — new seasons
+// are bootstrapped via Claude from a CBS URL or similar source (see
+// docs/admin-recipes.md). This page is for managing in-flight + historical
+// seasons.
+
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import type { SeasonStatus } from "@/lib/admin/season-types";
+
+export const dynamic = "force-dynamic";
+
+type SeasonRow = {
+  id: string;
+  name: string;
+  status: SeasonStatus;
+  start_date: string | null;
+  end_date: string | null;
+  created_at: string;
+};
+
+const STATUS_LABELS: Record<SeasonStatus, string> = {
+  setup: "Setup",
+  pre_season: "Pre-season",
+  active: "Active",
+  ended: "Ended",
+  results_published: "Results published",
+};
+
+const STATUS_CLASSES: Record<SeasonStatus, string> = {
+  setup: "bg-neutral-500/15 text-neutral-300 border-neutral-500/30",
+  pre_season: "bg-violet-500/15 text-violet-300 border-violet-500/30",
+  active: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+  ended: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+  results_published: "bg-sky-500/15 text-sky-300 border-sky-500/30",
+};
+
+export default async function AdminSeasonsPage() {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("seasons")
+    .select("id, name, status, start_date, end_date, created_at")
+    .order("created_at", { ascending: false });
+  const seasons = (data as SeasonRow[] | null) ?? [];
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <header className="mb-6">
+        <Link
+          href="/admin"
+          className="text-xs font-semibold uppercase tracking-widest text-neutral-500 hover:text-neutral-300"
+        >
+          ← Admin
+        </Link>
+        <h1 className="mt-1 text-2xl font-black tracking-tight text-neutral-100">
+          Seasons
+        </h1>
+        <p className="mt-1 text-sm text-neutral-400">
+          {seasons.length} {seasons.length === 1 ? "season" : "seasons"}. New
+          seasons are bootstrapped from source URLs via Claude — see{" "}
+          <code className="rounded bg-white/[0.04] px-1.5 py-0.5 text-xs">
+            docs/admin-recipes.md
+          </code>
+          .
+        </p>
+      </header>
+
+      {seasons.length === 0 ? (
+        <p className="rounded-2xl border border-white/10 bg-white/[0.02] p-5 text-sm text-neutral-400">
+          No seasons yet.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {seasons.map((season) => (
+            <li
+              key={season.id}
+              className="overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02] hover:bg-white/[0.04]"
+            >
+              <Link
+                href={`/admin/seasons/${season.id}`}
+                className="grid grid-cols-[1fr_auto_auto] items-center gap-4 p-4"
+              >
+                <div>
+                  <p className="text-base font-semibold text-neutral-100">
+                    {season.name}
+                  </p>
+                  {(season.start_date || season.end_date) && (
+                    <p className="mt-0.5 text-xs text-neutral-500">
+                      {season.start_date ?? "?"} — {season.end_date ?? "?"}
+                    </p>
+                  )}
+                </div>
+                <span className="hidden text-xs text-neutral-500 sm:block">
+                  created {new Date(season.created_at).toLocaleDateString()}
+                </span>
+                <span
+                  className={`rounded-full border px-2.5 py-0.5 text-xs font-semibold ${STATUS_CLASSES[season.status]}`}
+                >
+                  {STATUS_LABELS[season.status]}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/admin/SeasonDetail.tsx
+++ b/components/admin/SeasonDetail.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+// Admin season detail + status-transition console (issue #42).
+//
+// Edit affordances depend on status:
+//   setup / pre_season — name, dates, pricing constants all editable
+//   active+           — pricing locked (UI hides edit; DB trigger backstops);
+//                       name + dates stay editable for typo fixes
+//
+// Each forward step in the state machine is a one-button confirmation. The
+// terminal step (ended → results_published) calls publishSeasonResults
+// which runs the multi-step SQL function in one transaction.
+
+import { useState, useTransition } from "react";
+import {
+  advanceSeasonStatus,
+  publishSeasonResults,
+  updateSeasonMeta,
+} from "@/lib/admin/seasons";
+import { nextSeasonStatus, type SeasonStatus } from "@/lib/admin/season-types";
+
+export type AdminSeason = {
+  id: string;
+  name: string;
+  status: SeasonStatus;
+  startDate: string | null;
+  endDate: string | null;
+  startingBalance: number;
+  kConstant: number;
+  basePrice: number;
+};
+
+const STATUS_LABELS: Record<SeasonStatus, string> = {
+  setup: "Setup",
+  pre_season: "Pre-season",
+  active: "Active",
+  ended: "Ended",
+  results_published: "Results published",
+};
+
+const STATUS_CLASSES: Record<SeasonStatus, string> = {
+  setup: "bg-neutral-500/15 text-neutral-300 border-neutral-500/30",
+  pre_season: "bg-violet-500/15 text-violet-300 border-violet-500/30",
+  active: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+  ended: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+  results_published: "bg-sky-500/15 text-sky-300 border-sky-500/30",
+};
+
+const TRANSITION_LABEL: Record<SeasonStatus, { label: string; helpText: string } | null> = {
+  setup: {
+    label: "Publish to pre-season",
+    helpText: "Makes the season visible to users. No trading yet.",
+  },
+  pre_season: {
+    label: "Open trading",
+    helpText: "Pricing constants lock permanently after this step.",
+  },
+  active: {
+    label: "End season",
+    helpText: "Stops trading. Set winner / runner-up before publishing results.",
+  },
+  ended: {
+    label: "Publish results",
+    helpText: "Snapshots final standings + awards top_3 / top_10 badges.",
+  },
+  results_published: null,
+};
+
+type Props = { season: AdminSeason };
+
+export function SeasonDetail({ season }: Props) {
+  const [name, setName] = useState(season.name);
+  const [startDate, setStartDate] = useState(season.startDate ?? "");
+  const [endDate, setEndDate] = useState(season.endDate ?? "");
+  const [startingBalance, setStartingBalance] = useState(String(season.startingBalance));
+  const [kConstant, setKConstant] = useState(String(season.kConstant));
+  const [basePrice, setBasePrice] = useState(String(season.basePrice));
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const pricingLocked =
+    season.status === "active" || season.status === "ended" || season.status === "results_published";
+  const isTerminal = season.status === "results_published";
+
+  const metaDirty =
+    name !== season.name ||
+    startDate !== (season.startDate ?? "") ||
+    endDate !== (season.endDate ?? "") ||
+    (!pricingLocked &&
+      (Number(startingBalance) !== season.startingBalance ||
+        Number(kConstant) !== season.kConstant ||
+        Number(basePrice) !== season.basePrice));
+
+  const transition = TRANSITION_LABEL[season.status];
+
+  return (
+    <div>
+      {/* ── Status header ──────────────────────────────────── */}
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <span
+          className={`inline-block rounded-full border px-3 py-1 text-sm font-semibold ${STATUS_CLASSES[season.status]}`}
+        >
+          {STATUS_LABELS[season.status]}
+        </span>
+        {pricingLocked && (
+          <span className="text-xs text-neutral-500">
+            🔒 Pricing constants locked
+          </span>
+        )}
+      </div>
+
+      {/* ── Meta ──────────────────────────────────────────── */}
+      <section className="mb-6 rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="text-sm sm:col-span-2">
+            <span className="mb-1 block text-xs font-semibold text-neutral-400">
+              Name
+            </span>
+            <input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              disabled={isTerminal}
+              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-neutral-100 disabled:opacity-50"
+            />
+          </label>
+          <label className="text-sm">
+            <span className="mb-1 block text-xs font-semibold text-neutral-400">
+              Start date
+            </span>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(event) => setStartDate(event.target.value)}
+              disabled={isTerminal}
+              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-neutral-100 disabled:opacity-50"
+            />
+          </label>
+          <label className="text-sm">
+            <span className="mb-1 block text-xs font-semibold text-neutral-400">
+              End date
+            </span>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(event) => setEndDate(event.target.value)}
+              disabled={isTerminal}
+              className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm text-neutral-100 disabled:opacity-50"
+            />
+          </label>
+        </div>
+      </section>
+
+      {/* ── Pricing constants ─────────────────────────────── */}
+      <section className="mb-6 rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-bold uppercase tracking-widest text-neutral-400">
+            Pricing constants
+          </h2>
+          {pricingLocked && (
+            <span className="text-xs text-neutral-500">
+              Locked when trading opened
+            </span>
+          )}
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <PricingField
+            label="Starting balance ($)"
+            value={startingBalance}
+            onChange={setStartingBalance}
+            locked={pricingLocked}
+          />
+          <PricingField
+            label="K constant"
+            value={kConstant}
+            onChange={setKConstant}
+            locked={pricingLocked}
+            step="0.00000001"
+          />
+          <PricingField
+            label="Base price ($)"
+            value={basePrice}
+            onChange={setBasePrice}
+            locked={pricingLocked}
+            step="0.0001"
+          />
+        </div>
+      </section>
+
+      {error && (
+        <p className="mb-4 rounded-lg border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-200">
+          {error}
+        </p>
+      )}
+
+      {/* ── Save changes ──────────────────────────────────── */}
+      {!isTerminal && (
+        <div className="mb-6 flex items-center justify-end">
+          <button
+            type="button"
+            disabled={pending || !metaDirty}
+            onClick={() =>
+              startTransition(async () => {
+                setError(null);
+                const fields: Parameters<typeof updateSeasonMeta>[1] = {
+                  name,
+                  start_date: startDate || null,
+                  end_date: endDate || null,
+                };
+                if (!pricingLocked) {
+                  fields.starting_balance = Number(startingBalance);
+                  fields.k_constant = Number(kConstant);
+                  fields.base_price = Number(basePrice);
+                }
+                const result = await updateSeasonMeta(season.id, fields);
+                if (!result.ok) setError(result.error);
+              })
+            }
+            className="rounded-lg bg-sky-500 px-4 py-2 text-sm font-bold uppercase tracking-wider text-white shadow-lg shadow-sky-500/30 hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-neutral-700 disabled:text-neutral-400 disabled:shadow-none"
+          >
+            Save changes
+          </button>
+        </div>
+      )}
+
+      {/* ── Status transition ─────────────────────────────── */}
+      {transition && (
+        <section className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+          <p className="text-xs text-neutral-500">{transition.helpText}</p>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => {
+              if (!confirm(`${transition.label}? This step is forward-only.`)) return;
+              startTransition(async () => {
+                setError(null);
+                const result =
+                  season.status === "ended"
+                    ? await publishSeasonResults(season.id)
+                    : await advanceSeasonStatus(season.id);
+                if (!result.ok) setError(result.error);
+              });
+            }}
+            className={`rounded-lg px-4 py-2 text-sm font-bold uppercase tracking-wider shadow-lg disabled:opacity-50 ${
+              nextSeasonStatus(season.status) === "active"
+                ? "bg-emerald-500 text-white shadow-emerald-500/30 hover:bg-emerald-400"
+                : nextSeasonStatus(season.status) === "ended"
+                  ? "bg-amber-500 text-neutral-900 shadow-amber-500/30 hover:bg-amber-400"
+                  : "bg-sky-500 text-white shadow-sky-500/30 hover:bg-sky-400"
+            }`}
+          >
+            {transition.label}
+          </button>
+        </section>
+      )}
+
+      {isTerminal && (
+        <section className="rounded-2xl border border-sky-500/30 bg-sky-500/10 p-4 text-sm text-sky-100">
+          🏁 This season is complete. Results published — final standings and
+          badges are live.
+        </section>
+      )}
+    </div>
+  );
+}
+
+function PricingField({
+  label,
+  value,
+  onChange,
+  locked,
+  step,
+}: {
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  locked: boolean;
+  step?: string;
+}) {
+  return (
+    <label className="text-sm">
+      <span className="mb-1 block text-xs font-semibold text-neutral-400">{label}</span>
+      <input
+        type="number"
+        step={step ?? "0.01"}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        readOnly={locked}
+        className={`w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-sm tabular-nums ${
+          locked ? "text-neutral-500" : "text-neutral-100"
+        }`}
+      />
+    </label>
+  );
+}

--- a/docs/admin-recipes.md
+++ b/docs/admin-recipes.md
@@ -1,0 +1,123 @@
+# Admin recipes (Claude-orchestrated)
+
+*Operations that don't have a UI in the app — driven by Claude with the Supabase MCP tools.*
+
+The everyday admin work (managing contestants, building surveys, driving season status transitions) lives in `/admin/*` as a real UI. **Two things stay outside the app**, because they happen rarely enough that a polished form would be a poor ROI:
+
+1. **Bootstrapping a new season + initial contestants** — once per ~3 months
+2. **Bulk contestant operations** — rarely needed; ad-hoc when it is
+
+Both are handled by asking Claude in this repo's session: "Set up Big Brother 28 from <CBS URL>." Claude reads the source, extracts structured data, and writes the rows via the Supabase MCP.
+
+---
+
+## Recipe 1 — Bootstrap a new season from a source URL
+
+**When the user says:** *"Set up Big Brother 28, here's the CBS cast page: <url>"*
+
+### Step 1 — Confirm the season number is unused
+
+```sql
+select id, name, status::text from seasons order by created_at desc;
+```
+
+If a season with this number already exists, ask the user whether they want to overwrite it (rare).
+
+### Step 2 — Insert the season row
+
+```sql
+insert into seasons (name, status, start_date, end_date, starting_balance, k_constant, base_price)
+values (
+  'Big Brother 28',          -- match the format of past names (numbers, not roman numerals)
+  'setup',                    -- always start here; the admin transitions forward in the UI
+  '<premiere date>',          -- YYYY-MM-DD; from the source page
+  '<finale date or estimate>',-- YYYY-MM-DD; the admin can adjust later
+  1000.00,                    -- starting_balance — DEFAULT unless the user says otherwise
+  0.50,                       -- k_constant — see docs/pricing-formula.md
+  1.00                        -- base_price — see docs/pricing-formula.md
+)
+returning id;
+```
+
+> **Pricing defaults**: `1000 / 0.50 / 1.00` are the values used for BB27 (see `supabase/seed.sql`). Only change them if the user explicitly tells you to. Once the season's status goes to `active`, the DB trigger blocks any further writes to these columns — so getting them right at insert time matters.
+
+### Step 3 — Scrape the cast page
+
+Use `WebFetch` against the source URL. CBS pages typically have a structured list of cast members with:
+- **name** (full name, "First Last")
+- **bio** (short paragraph — keep ≤300 chars, trim if longer)
+- **photo URL** (direct image link; verify it's accessible)
+
+If the source is messy (Wikipedia, Reddit roster posts), normalize aggressively. **Show the user the extracted list before inserting** and ask if any names look wrong.
+
+### Step 4 — Insert contestants
+
+```sql
+insert into contestants (season_id, name, photo_url, bio, status, total_shares_outstanding)
+values
+  ('<season_id>', 'Janelle Pierzina', 'https://…', 'BB legend returning for one more run.', 'active', 0),
+  ('<season_id>', 'Angela Rummans',  'https://…', 'Former athlete known for cold strategic gameplay.', 'active', 0),
+  -- …one row per cast member…
+;
+```
+
+> **`total_shares_outstanding = 0`** at season start. The bonding curve starts here; users buying shares moves it up.
+>
+> **`status = 'active'`** for everyone. Evictions get tracked through the admin UI later.
+
+### Step 5 — Hand back to the admin
+
+Confirm the count and the season id. The admin then opens `/admin/seasons/<id>` to drive the status transitions when they're ready.
+
+---
+
+## Recipe 2 — End a season + publish results
+
+The admin can do this entirely through `/admin/seasons/<id>` — but documenting the SQL path for clarity / emergency recovery.
+
+### Step 1 — Verify the season is in `ended` state
+
+```sql
+select status::text from seasons where id = '<season_id>';
+-- must return 'ended'
+```
+
+If it's still `active`, the admin needs to end it first via the UI (or `update seasons set status = 'ended' where id = ...`).
+
+### Step 2 — Publish results
+
+```sql
+select publish_season_results('<season_id>');
+```
+
+This function (defined in `0007_season_management.sql`) is transactional. It:
+- Refreshes `portfolios.net_worth` one final time
+- Snapshots `season_results` (one row per user with `final_rank` + `final_net_worth`)
+- Awards `top_10` badges to ranks 1–10 and `top_3` badges to ranks 1–3
+- Flips `seasons.status` to `'results_published'`
+
+Idempotent — safe to re-run; the `ON CONFLICT DO NOTHING` clauses prevent duplicates. But it will refuse if status isn't `ended`.
+
+---
+
+## Recipe 3 — Why some pricing edits fail
+
+When the admin tries to change `starting_balance`, `k_constant`, or `base_price` on an active+ season, the DB trigger raises a `check_violation`:
+
+> Pricing constants are locked once a season goes active
+
+This is the **load-bearing safety rail** for CLAUDE.md's hard rule: pricing constants are permanently immutable once trading opens. The trigger fires on `BEFORE UPDATE` to `seasons` and rejects any change to those three columns when `OLD.status IN ('active','ended','results_published')`. The admin UI hides the fields, but the trigger backstops any other write path — Claude included.
+
+**There's no override.** If a pricing constant truly needs to change, that's a new season.
+
+---
+
+## Recipe 4 — Local seed reset (development only)
+
+Not season-specific but adjacent: if local state gets messy during testing,
+
+```bash
+supabase db reset --local
+```
+
+re-applies all migrations + `seed.sql`. The seed has BB27 with 10 contestants and 4 surveys (one in each state). **Never run on staging or production.**

--- a/lib/admin/season-types.ts
+++ b/lib/admin/season-types.ts
@@ -1,0 +1,22 @@
+// Types + pure helpers for season management. Kept separate from
+// lib/admin/seasons.ts because that file is `"use server"` and can only
+// export async server actions.
+
+export type SeasonStatus =
+  | "setup"
+  | "pre_season"
+  | "active"
+  | "ended"
+  | "results_published";
+
+const NEXT_STATUS: Record<SeasonStatus, SeasonStatus | null> = {
+  setup: "pre_season",
+  pre_season: "active",
+  active: "ended",
+  ended: "results_published",
+  results_published: null,
+};
+
+export function nextSeasonStatus(status: SeasonStatus): SeasonStatus | null {
+  return NEXT_STATUS[status];
+}

--- a/lib/admin/seasons.ts
+++ b/lib/admin/seasons.ts
@@ -1,0 +1,125 @@
+"use server";
+
+// Admin season management actions (issue #42).
+//
+// New-season creation lives outside the app — Claude orchestrates it from
+// the source URL (see docs/admin-recipes.md). What's here is the operational
+// machinery: edit the in-flight season's metadata, drive its status forward,
+// publish results.
+//
+// State machine (forward-only):
+//
+//   setup ──▶ pre_season ──▶ active ──▶ ended ──▶ results_published
+//
+// Pricing constants (starting_balance, k_constant, base_price) lock once the
+// season crosses into `active`. The DB trigger added in 0007 is the backstop;
+// the UI hides the fields, but anyone — Claude included — bypassing the UI
+// gets a `check_violation` from Postgres.
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { nextSeasonStatus, type SeasonStatus } from "./season-types";
+
+type ActionResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+type SeasonRow = {
+  id: string;
+  status: SeasonStatus;
+};
+
+async function loadSeason(id: string): Promise<SeasonRow | null> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("seasons")
+    .select("id, status")
+    .eq("id", id)
+    .maybeSingle();
+  return data as SeasonRow | null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Metadata
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Update editable season fields. The DB trigger blocks writes to the pricing
+ * columns once status crosses into active, so this action accepts them
+ * optimistically and surfaces the trigger's exception as the action error.
+ */
+export async function updateSeasonMeta(
+  id: string,
+  fields: {
+    name?: string;
+    start_date?: string | null;
+    end_date?: string | null;
+    starting_balance?: number;
+    k_constant?: number;
+    base_price?: number;
+  },
+): Promise<ActionResult> {
+  if (Object.keys(fields).length === 0) return { ok: true };
+  const supabase = await createClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase.from("seasons") as any).update(fields).eq("id", id);
+  if (error) {
+    // Surface the trigger's hint when present.
+    return {
+      ok: false,
+      error: error.message.includes("Pricing constants")
+        ? "Pricing constants are locked — they can only be edited during setup or pre-season."
+        : error.message,
+    };
+  }
+  revalidatePath("/admin/seasons");
+  revalidatePath(`/admin/seasons/${id}`);
+  return { ok: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Status transitions
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Move a season one step forward in its state machine. Refuses any non-
+ * sequential transition. The terminal step (ended → results_published) goes
+ * through `publishSeasonResults` instead, since it has side effects.
+ */
+export async function advanceSeasonStatus(id: string): Promise<ActionResult> {
+  const season = await loadSeason(id);
+  if (!season) return { ok: false, error: "not-found" };
+  const next = nextSeasonStatus(season.status);
+  if (!next) return { ok: false, error: "already-terminal" };
+  if (next === "results_published") {
+    return { ok: false, error: "use-publish-season-results" };
+  }
+
+  const supabase = await createClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase.from("seasons") as any)
+    .update({ status: next })
+    .eq("id", id);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/admin/seasons");
+  revalidatePath(`/admin/seasons/${id}`);
+  return { ok: true };
+}
+
+/**
+ * Wrap the multi-step terminal transition. The SQL function handles the
+ * snapshot + badges + status flip in one transaction.
+ */
+export async function publishSeasonResults(id: string): Promise<ActionResult> {
+  const supabase = await createClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase as any).rpc("publish_season_results", {
+    p_season_id: id,
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/admin/seasons");
+  revalidatePath(`/admin/seasons/${id}`);
+  return { ok: true };
+}

--- a/supabase/migrations/0007_season_management.sql
+++ b/supabase/migrations/0007_season_management.sql
@@ -1,0 +1,113 @@
+-- ============================================================
+-- Reality Stock Watch — Season management (#42)
+--
+-- Two pieces:
+--   1. `enforce_pricing_lock` trigger — backstops the CLAUDE.md hard rule
+--      "Pricing constants lock permanently when a season goes Active". Once
+--      a season's status crosses into active/ended/results_published, the
+--      starting_balance, k_constant, and base_price columns become immutable.
+--      Other columns (name, dates, status itself) stay editable so admins
+--      can still drive transitions and fix typos.
+--
+--   2. `publish_season_results(season_id)` — the multi-step ended → results-
+--      published transition, in one transaction:
+--        a. Final refresh_net_worth() so the snapshot is current
+--        b. Insert season_results rows (rank by net_worth desc)
+--        c. Award top_3 + top_10 badges (top_10 is inclusive, top_3 is the
+--           stricter subset; a #1 user gets both)
+--        d. Flip seasons.status to 'results_published'
+--      Designed to be called either from the admin server action OR via
+--      Claude/SQL when wrapping up a real season.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- Trigger: lock pricing constants once a season goes active
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION enforce_pricing_lock() RETURNS TRIGGER AS $$
+BEGIN
+  -- The status flip itself isn't blocked — only writes to the locked columns.
+  -- IS DISTINCT FROM handles the NULL case naturally; even though the columns
+  -- are NOT NULL today, future-proofing costs nothing.
+  IF OLD.status IN ('active', 'ended', 'results_published')
+     AND (NEW.starting_balance IS DISTINCT FROM OLD.starting_balance
+          OR NEW.k_constant      IS DISTINCT FROM OLD.k_constant
+          OR NEW.base_price      IS DISTINCT FROM OLD.base_price)
+  THEN
+    RAISE EXCEPTION 'Pricing constants are locked once a season goes active'
+      USING ERRCODE = 'check_violation',
+            HINT = 'starting_balance, k_constant, and base_price can only be edited during setup/pre_season';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS seasons_pricing_lock ON seasons;
+CREATE TRIGGER seasons_pricing_lock
+  BEFORE UPDATE ON seasons
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_pricing_lock();
+
+-- ------------------------------------------------------------
+-- Function: publish_season_results
+-- ------------------------------------------------------------
+-- SECURITY DEFINER so an admin's user-scoped session can call it without
+-- needing direct write access to badges/season_results — the function
+-- enforces the gate (status must be 'ended') and runs as the function owner.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION publish_season_results(p_season_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_status season_status;
+BEGIN
+  -- Gate: only an 'ended' season can graduate. Anything else is a no-op
+  -- error so the caller learns the state machine fast.
+  SELECT status INTO v_status FROM seasons WHERE id = p_season_id;
+  IF v_status IS NULL THEN
+    RAISE EXCEPTION 'Season % not found', p_season_id;
+  END IF;
+  IF v_status <> 'ended' THEN
+    RAISE EXCEPTION 'Season must be in `ended` state before publishing results (currently %)', v_status;
+  END IF;
+
+  -- Final net_worth refresh so the snapshot matches what users see.
+  PERFORM refresh_net_worth();
+
+  -- Snapshot the final standings. ROW_NUMBER over net_worth desc is the
+  -- canonical rank; ties broken arbitrarily by portfolio.id ordering — which
+  -- mirrors how get_leaderboard's RANK() window resolves ties anyway.
+  INSERT INTO season_results (user_id, season_id, final_rank, final_net_worth)
+  SELECT
+    user_id,
+    p_season_id,
+    ROW_NUMBER() OVER (ORDER BY net_worth DESC, id),
+    net_worth
+  FROM portfolios
+  WHERE season_id = p_season_id
+  ON CONFLICT (user_id, season_id) DO NOTHING;
+
+  -- Award badges. top_10 is the inclusive bucket (ranks 1-10); top_3 is the
+  -- stricter subset (ranks 1-3). A rank-1 user gets BOTH badges by design —
+  -- get_leaderboard already returns badges as a list, so stacking is fine.
+  -- ON CONFLICT DO NOTHING makes the function idempotent on re-runs.
+  INSERT INTO badges (user_id, season_id, type)
+  SELECT user_id, p_season_id, 'top_10'::badge_type
+  FROM season_results
+  WHERE season_id = p_season_id AND final_rank BETWEEN 1 AND 10
+  ON CONFLICT (user_id, season_id, type) DO NOTHING;
+
+  INSERT INTO badges (user_id, season_id, type)
+  SELECT user_id, p_season_id, 'top_3'::badge_type
+  FROM season_results
+  WHERE season_id = p_season_id AND final_rank BETWEEN 1 AND 3
+  ON CONFLICT (user_id, season_id, type) DO NOTHING;
+
+  -- Finally flip status.
+  UPDATE seasons SET status = 'results_published' WHERE id = p_season_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION publish_season_results(uuid) TO authenticated;


### PR DESCRIPTION
Closes #42. Final Phase 4 admin surface, with the revised scope you set: operational management lives in the app; bootstrapping a new season + initial contestants is Claude-orchestrated from a source URL (no in-app create form, no AI scraping, no photo drag-drop).

## DB invariants (migration 0007)
- **`enforce_pricing_lock` BEFORE-UPDATE trigger** on `seasons` — rejects any write to `starting_balance` / `k_constant` / `base_price` once `status >= active`. The load-bearing safety net for CLAUDE.md's hard rule; backstops any write path (admin UI, Claude, SQL console, future bugs). Status flips themselves + name/date edits still pass through.
- **`publish_season_results(season_id)`** `SECURITY DEFINER` function — transactional `ended → results_published`:
  1. Refresh `portfolios.net_worth`
  2. Snapshot `season_results` (rank by net_worth desc, ties broken by id)
  3. Award `top_10` (ranks 1–10) + `top_3` (ranks 1–3) badges, `ON CONFLICT DO NOTHING`
  4. Flip status to `results_published`

  Refuses non-ended seasons. Idempotent on re-runs.

## App surfaces
- **`lib/admin/season-types.ts`** — shared `SeasonStatus` + `nextSeasonStatus` helper. Separate file because action files are `"use server"` and can only export async functions.
- **`lib/admin/seasons.ts`** — `updateSeasonMeta`, `advanceSeasonStatus`, `publishSeasonResults`. Translates the trigger's check_violation into friendlier copy.
- **`/admin/seasons`** — list of all seasons with status badges. **No create button** — explainer links to `docs/admin-recipes.md`.
- **`/admin/seasons/[id]`** — meta form, pricing-constants card (locked when status >= active with a 🔒 indicator), per-status transition button with help text, celebration card for the terminal state.
- **`/admin`** — added Seasons link above Contestants.

## Recipe doc
- **`docs/admin-recipes.md`** — how to bootstrap a new season from a CBS URL (verify number, insert season row, scrape cast, insert contestants), plus reference SQL for `publish_season_results`. Linked from CLAUDE.md.

## Verified end-to-end (local seed)
- ✅ Trigger blocks `update seasons set k_constant = 9.99 where status='active'` with the exact error the action surfaces.
- ✅ Trigger permits name/dates edits on an active season.
- ✅ Trigger permits pricing edits on a setup season.
- ✅ `publish_season_results` refuses non-ended (returns the "currently setup" error).
- ✅ Walked BB27 through Active → Ended → Results Published via the UI buttons; confirmed in DB: 5 `season_results` rows (ranks 1–5 by net worth desc), 5 `top_10` + 3 `top_3` badges, status `results_published`. Screenshot of the celebration card in PR comments.
- ✅ `pnpm typecheck`, `pnpm test` (11 pass), `pnpm build` clean (all admin routes registered).

## Phase 4 is complete
After this merges:
- ✅ #42 season management (this PR)
- ✅ #43 contestants (#84)
- ✅ #44 surveys (#85)

Plus #74 (env hardening) remains as a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)