### PR TITLE
Refine the layers flow docs for Reality Stock Watch

### DIFF
--- a/docs/design/conceptual-model.md
+++ b/docs/design/conceptual-model.md
@@ -40,7 +40,7 @@
 ---
 
 ### Trade
-*A record of a single buy or sell transaction on a contestant's stock.*
+*A record of a single buy or sell transaction on a contestant.*
 
 | | |
 |---|---|
@@ -127,11 +127,9 @@
 
 | | |
 |---|---|
-| **Attributes** | text, type (TBD — ranking, multiple choice, etc.), display order |
+| **Attributes** | text, type (ranking, multiple choice, single choice), display order |
 | **Relationships** | belongs to one Survey |
 | **Actions** | (admin) Add · Edit · Reorder · Remove |
-
-> ⚠️ Question types TBD — to be resolved before building the survey builder.
 
 ---
 
@@ -270,8 +268,8 @@ Use these terms consistently — in the UI, in help text, in API names, in inter
 
 | Action | Chosen verb | Rejected | Applies to |
 |--------|------------|----------|------------|
-| Acquiring shares | **Buy** | Purchase, Invest, Acquire | Contestant stock |
-| Disposing of shares | **Sell** | Liquidate, Dump | Contestant stock |
+| Acquiring shares | **Buy** | Purchase, Invest, Acquire | Contestant shares |
+| Disposing of shares | **Sell** | Liquidate, Dump | Contestant shares |
 | Admin making season visible to players | **Publish** | Launch, Activate, Go live | Season (pre-season state), Survey, Survey results |
 | Admin opening trading | **Open** | Start, Activate, Launch | Season (active state) |
 | Admin closing season | **End** | Close, Finish, Wrap | Season |
@@ -286,3 +284,14 @@ Use these terms consistently — in the UI, in help text, in API names, in inter
 - [x] **Survey question types** — Ranking, Multiple choice, Single choice.
 - [ ] **Survey editing while active** — editing a Draft vs. an Active survey are different operations. Design as separate interactions to avoid corrupting in-flight responses.
 - [ ] **Results visibility** — survey results visible to logged-in users only after admin publishes. Confirm whether any results are ever public.
+
+---
+
+## Strategy Audit — 2026-06-11
+
+The provisional product strategy centers on helping users act on changing reads, trust the market result, and compare socially. The current model supports that loop without new first-class objects, but these model decisions should be kept visible:
+
+- [ ] **Trade as receipt** — a Trade currently records type, dollar amount, shares, price at execution, fee, state, and timestamp. If users need a shareable "good read" receipt, first test whether these attributes are enough before adding a new object such as Highlight, Receipt, or Notable Trade.
+- [ ] **Rank movement and price movement** — treat these as derived views for now, not first-class objects. Promote only if flows require persistent history independent of existing Trade, Portfolio, Leaderboard, and Contestant data.
+- [ ] **Anonymous survey handoff** — resolve whether an anonymous Survey Response can later attach to a User after signup. Current docs disagree; this is a conceptual relationship decision before it is an implementation detail.
+- [ ] **Badge and Season Result as social proof** — the current objects support end-of-season proof, but not mid-season "good read" proof. Keep that distinction explicit when designing sharing or public profile flows.

--- a/docs/design/interaction-flow-audit.md
+++ b/docs/design/interaction-flow-audit.md
@@ -1,0 +1,51 @@
+# Interaction Flow Audit — Reality Stock Watch
+
+*Created: 2026-06-11. Framework: Layers of Product Design. Source: product strategy and existing interaction-flow docs.*
+
+This audit checks the existing breadboards against the provisional strategy: first-trade activation, market trust, and return behaviour.
+
+---
+
+## What Is Stable
+
+- The main places are coherent: Market, Contestant, Trade overlay, Portfolio, Leaderboard, Survey, Admin.
+- The Trade overlay has the right structural shape for fast action: generic, contestant-selectable, Buy/Sell in one place, at-market result state.
+- Portfolio and Leaderboard are correctly separated as return destinations.
+- Survey has a clear state machine and separates anonymous public-link behaviour from logged-in app behaviour.
+- Admin flows cover the high-stakes state transitions with confirmation.
+
+---
+
+## Flow Decisions To Revisit
+
+| Flow | Decision | Why it matters |
+|------|----------|----------------|
+| Onboarding → Market | Whether first active-season arrival needs a first-trade prompt or contextual empty state. | Strategy assumes first Trade is the strongest activation signal. Current flow trusts users to orient themselves. |
+| Market → Trade | Whether a global Trade affordance belongs in top-level navigation or only contextual rows/detail pages. | Fast action matters when a fan has a read before choosing a screen path. |
+| Trade overlay | How much explanation appears before submit vs. after fill. | Trust depends on understanding preview, execution, fee, and price movement without slowing the trade. |
+| Trade result → Return destination | Whether filled trade dismissal should return passively or offer Portfolio/Leaderboard as next actions. | Return loop depends on users checking whether their read is paying off. |
+| Portfolio | Whether holdings need a "what changed since my trade" view. | Users may need feedback beyond current value to understand whether a read worked. |
+| Leaderboard | Exact "Find me" behaviour when the user is outside the first loaded page. | Community comparison fails if users cannot locate themselves quickly. |
+| Survey results | Whether results should link back to contestants or trading decisions. | Strategy treats surveys as supporting the trading loop unless research proves they are separate. |
+
+---
+
+## Edge States To Preserve
+
+- Trade failed: diagnose, explain, and recover with amount preserved.
+- Trade filled after price movement: show execution vs. preview only when meaningful enough to avoid noise.
+- Realtime miss or lag: page refresh should re-seed from server data.
+- Empty holdings: route toward first trade without using "stock" vocabulary.
+- Empty leaderboard: make early beta feel alive enough without inventing fake competition.
+- Anonymous survey closed: remain standalone, no forced app navigation.
+
+---
+
+## Handoff To Surface
+
+Surface work should focus on:
+
+- Plain-language market feedback.
+- Vocabulary consistency around Contestant, Trade, Holding, Portfolio, Cash, Season Result, Badge.
+- Hierarchy on Market, Trade result, Portfolio, and Leaderboard so the core loop is obvious.
+- Error and loading states that explain what happened and what to do next.

--- a/docs/design/interaction-flow-portfolio-leaderboard.md
+++ b/docs/design/interaction-flow-portfolio-leaderboard.md
@@ -41,7 +41,7 @@ Portfolio
   Portfolio — Holdings tab
   - tap holding row → Contestant (active)
   [ list: contestant, shares held, avg purchase price, liquidation value, gain/loss on this holding ]
-  [ empty state: "No holdings yet — buy your first stock to get started" ]
+  [ empty state: "No holdings yet — buy your first Contestant shares to get started" ]
 
   Portfolio — History tab
   - load more → appends next page (explicit button, not infinite scroll)

--- a/docs/design/interaction-flow-trading.md
+++ b/docs/design/interaction-flow-trading.md
@@ -6,7 +6,7 @@
 
 ## Job story
 
-When I want to act on my read of the BB game, I want to buy or sell contestant stock quickly so I can put my reads on the line and get back to watching.
+When I want to act on my read of the BB game, I want to buy or sell contestant shares quickly so I can put my reads on the line and get back to watching.
 
 ---
 
@@ -45,7 +45,7 @@ Market — Active
 - tap Trade on contestant row → Trade overlay — Entry (buy default)
 [ live list: contestant name, current price, 24h change, your holding per contestant ]
 [ cash balance ]
-[ prices tick every 2–3s — subtle update animation ]
+[ prices update when trades change contestant supply — subtle update animation ]
 
 ---
 
@@ -63,7 +63,7 @@ Contestant — Active
 [ photo, name, status badge ]
 [ visual flags: HoH / Nominated / Veto / Evicted — display only ]
 [ live price + price movement ]
-[ your holding: shares held, avg purchase price, liquidation value, unrealised P&L ]
+[ your holding: shares held, avg purchase price, liquidation value, gain/loss in plain language ]
 [ empty holding state: "You don't own any shares in [name]" ]
 
 ---
@@ -156,7 +156,7 @@ graph LR
 - [ ] **Partial sells** — user can sell any dollar amount up to their full holding's liquidation value. Max input in sell mode = current liquidation value. ⚠️ Confirm this is the intended behavior before building.
 - [ ] **Global Trade button** — generic overlay can be triggered from anywhere. Consider a persistent FAB or nav action so users can trade without navigating to a specific contestant first. Surface decision.
 - [ ] **Contestant selector UX** — inside the overlay, how does the user pick/change a contestant? Dropdown, search, scrollable list? Surface decision.
-- [ ] **Price tick animation** — prices update every 2–3s. Subtle flash/fade on update. Style TBD at surface layer.
+- [ ] **Price update animation** — prices update when Realtime contestant supply changes. Subtle flash/fade on update. Style TBD at surface layer.
 - [ ] **Trade button placement on list row** — single "Trade" button. Where on the row? Rightmost affordance recommended but surface decision.
 - [ ] **Price shift threshold** — show "Executed at / Preview was" message only if delta exceeds X%. Avoids noise on tiny movements. Threshold TBD.
 

--- a/docs/design/layers-flow-plan.md
+++ b/docs/design/layers-flow-plan.md
@@ -1,0 +1,67 @@
+# Layers Flow Plan — Reality Stock Watch
+
+*Created: 2026-06-11. Framework: Layers of Product Design.*
+
+This plan defines how to refine the product design documentation for this repo using the `/layers-*` skills. The goal is not to generate a complete new document set. The goal is to make and capture the decisions that are currently live, starting from the lowest unresolved layer and moving upward only when lower-layer work changes what depends on it.
+
+---
+
+## Current Orientation
+
+The 2026-06-11 `/layers-orient` rerun identifies **Observed behaviour** as the current bottleneck.
+
+| Layer | Current state | What that means for this pass |
+|-------|---------------|-------------------------------|
+| Observed behaviour | Partial | Synthesize existing evidence and plan lightweight research for the current 24/7 version. |
+| The domain | Strong | Quick check only unless research reveals missing BB/RHAP concepts. |
+| User needs | Partial | Refine after observed-behaviour work, using confidence ratings. |
+| Product & service strategy | Partial | Decide what v1 optimizes for and how success will be measured. |
+| Conceptual model | Strong | Audit for drift after strategy/needs are clearer; do not rewrite from scratch. |
+| Interaction structure | Strong | Update flows only where research, strategy, or model decisions change journeys. |
+| Surface | Partial | Capture surface principles and cleanup targets after lower layers settle. |
+
+---
+
+## Working Sequence
+
+1. **Observed behaviour** — create an evidence inventory, mark confidence, name learning goals, and define a small research plan.
+2. **User needs** — convert evidence into candidate job stories and prioritize the needs v1 should serve.
+3. **Product & service strategy** — choose the primary engagement loop, define success metrics, and clarify what remains out of scope.
+4. **Conceptual model audit** — check the current object/state/vocabulary docs against the strategy and implementation.
+5. **Interaction flow audit** — update breadboards where the model or strategy changed the user journey.
+6. **Surface audit** — document copy, hierarchy, visual feedback, and component-pattern decisions that should stay consistent across shipped UI.
+
+Domain gets a short audit between observed behaviour and user needs only if new research reveals missing or misnamed BB/RHAP concepts.
+
+---
+
+## Capture Rules
+
+- Save decisions and open questions, not transcripts.
+- Prefer editing existing design docs when a decision belongs there.
+- Add a new Markdown file only when the decision set does not already have a clear home.
+- Use confidence labels for research-derived claims: **Observed**, **Inferred**, **Assumed**.
+- Keep diagrams only when they encode a decision. Mermaid labels should use `<br/>` for line breaks.
+
+---
+
+## Documentation Targets
+
+| Step | Likely file |
+|------|-------------|
+| Observed behaviour | `docs/design/observed-behaviour.md` |
+| User needs | `docs/design/user-needs.md` |
+| Product strategy | `docs/design/product-strategy.md` |
+| Conceptual model audit | `docs/design/conceptual-model.md` |
+| Interaction flow audit | `docs/design/interaction-flow-*.md` |
+| Surface audit | `docs/design/surface-guidelines.md` |
+
+---
+
+## Current Open Threads To Carry Forward
+
+- What direct evidence shows that a 24/7 market is better for this audience than trading windows?
+- What does a user need to understand about bonding-curve pricing before they trust trades?
+- Which engagement loop should v1 optimize: trading, leaderboard comparison, surveys, livestream reveal, or Discord sharing?
+- What beta behaviour would prove the product is working?
+- Which cross-doc drifts need canonical decisions: realtime pricing model, anonymous survey handoff, pricing defaults vs. final calibration, and vocabulary leakage?

--- a/docs/design/layers-orient.md
+++ b/docs/design/layers-orient.md
@@ -1,58 +1,77 @@
 # Layers Orient — Reality Stock Watch
 
-*Session date: 2026-05-15. Framework: Layers of Product Design.*
+*Rerun date: 2026-06-11. Framework: Layers of Product Design. Skill version: upgraded `/layers-orient`.*
+
+This pass re-runs the orient diagnostic against the current project documentation and shipped code. The previous orient session from 2026-05-15 identified **Conceptual Model** as the bottleneck because core objects, states, and flows were not yet documented. Since then, the product has gained a documented conceptual model, interaction-flow docs, schema, pricing formula, and working implementations for market/trading, survey, admin season management, portfolio/leaderboard surfaces, push subscription APIs, and the livestream reveal tool.
 
 ---
 
 ## Layer Audit
 
-| Layer                     | State    | Notes |
-|---------------------------|----------|-------|
-| Observed behaviour        | Partial  | Real operational data from prior app: market windows caused friction, load/data volume caused technical failures. 24/7 decision is evidence-based. No formal user research. |
-| The domain                | Strong   | Deep BB knowledge (HOH, nominations, veto, live feeds, evictions, RHAP community). Not a risk. |
-| User needs                | Partial  | "Social competition and sharing stats in Discord" is a real articulation. Underlying job: express reads on the game, compete low-stakes with other fans. Not formally documented but coherent. |
-| Product & service strategy | Partial | Goal: minimize infra cost, ship something real. Monetization deferred. Success metric is informal — no explicit KPIs. Business model is open. |
-| Conceptual model          | Assumed  | Team has a shared mental model but it isn't documented. Key objects (Stock, Contestant, Season, Trade, Portfolio, Survey, Badge) and their relationships/states are undefined. Critical states (eviction behavior, price formula) are explicitly TBD. |
-| Interaction structure     | Not started | No flows, breadboards, or user journeys exist yet. |
-| Surface                   | Not started | No design system or visual language defined. |
+| Layer | State | Notes |
+|-------|-------|-------|
+| Observed behaviour | Partial | Evidence still comes mostly from the prior app and operational memory: trading windows caused friction, load/data volume failed, RHAP/BB fans are socially competitive. The current 24/7 bonding-curve version has no documented user interviews, usability sessions, analytics, or beta learnings yet. |
+| The domain | Strong | The docs show strong command of BB concepts, RHAP context, season cadence, surveys, live-feed discourse, evictions, re-entry, HOH, nominations, veto, finale states, and public-link fan participation. Domain understanding is not the current risk. |
+| User needs | Partial | The underlying job is coherent: fans want to express reads on the season, compete socially, and compare takes. This is embedded in flow job stories, but not yet validated or prioritized against observed behaviour. Needs around casual onboarding, Discord sharing, and survey result consumption remain assumed. |
+| Product & service strategy | Partial | v1 scope is reasonably explicit: BB US only, fake money, PWA, no paid service dependencies, low infrastructure cost, survey integration, admin-driven seasons. Success measures, retention goals, paid-tier strategy, and what behaviour would prove the product is working remain informal. |
+| Conceptual model | Strong | Core objects, relationships, states, vocabulary, pricing mechanics, schema, and trade invariants are documented and mostly implemented. Remaining decisions are bounded: all-time leaderboard scoring, survey editing while active, results visibility, and exact end-of-season trading/finale semantics. |
+| Interaction structure | Strong | Major flows are breadboarded: onboarding, trading, portfolio/leaderboard, survey, admin, and shipped livestream reveal. Several flows are also represented in working code. Remaining open items are mostly localized interaction/surface decisions, not missing structure. |
+| Surface | Partial | The app has a consistent dark, mobile-first Tailwind/Base UI language and shipped screens, but no formal surface guidelines or component system beyond local patterns. Some copy and visual decisions remain open: homepage copy, badge treatment, contestant selector details, price animation, and leaderboard “Find me” behaviour. |
 
 ---
 
 ## Bottleneck Analysis
 
-**Bottleneck: Conceptual Model**
+**Bottleneck: Observed behaviour**
 
-This is the lowest layer with unresolved, risky decisions — and the most load-bearing one for this product.
+This is now the lowest layer with unresolved risk. The product has moved upward substantially since the first orient pass: the conceptual model and interaction structure are no longer absent. The remaining foundational weakness is that many product choices are based on domain expertise, prior-app lessons, and plausible RHAP-community assumptions rather than direct evidence from the current 24/7 version.
 
-The conceptual model for Reality Stock Watch is complex:
-- Multiple interconnected object types (Contestant, Stock, Season, Trade, Portfolio, Survey, Badge, Leaderboard)
-- Key state transitions are undefined — **eviction behavior is explicitly flagged as critical and TBD**
-- The pricing formula is deferred ("owner will provide logic") — but this *is* the conceptual model for how Stocks behave
-- The Survey's relationship to Stock prices is unresolved (does it influence prices or is it purely informational?)
-- The prior app had a fundamentally different model (trading windows, rating-based pricing) — the new model hasn't been formally articulated to replace it
+The risk is not that the team does not understand Big Brother. The risk is that the new mechanics may change user behaviour:
 
-Everything above — interaction flows, surface design, infrastructure decisions — will be built on this foundation. Getting it wrong here creates rework at every layer above it.
+- A 24/7 market may reduce urgency compared with trading windows, or it may create more compulsive checking.
+- A bonding curve may be understood by hardcore fans as “market vibes,” or it may feel opaque/unfair without better explanation.
+- The survey and livestream reveal work may be a major engagement loop, or it may remain separate from the trading game in users' minds.
+- Social competition is assumed to matter, but Discord sharing, leaderboard motivation, badges, and all-time ranking have not been validated as the right expressions of that need.
 
-**Also flag: assumed layers**
+**Assumed layers to watch**
 
-- *Observed behaviour* is treated as solid but it's from a different product with different rules. User behavior in a 24/7 market may differ significantly from what was observed with trading windows. Don't over-index on old data.
-- *User needs* is coherent but thin. "Social competition" is the job — but the specific mechanics that serve that need (leaderboard shape, sharing format, Discord integration) haven't been tested against real users.
+- **User needs:** “Express my read and compete with other fans” is credible, but still thin. It should be tested with RHAP users before investing heavily in secondary loops like all-time leaderboard scoring, public profiles, or paid tiers.
+- **Product strategy:** Cost minimization and v1 scope are clear; success criteria are not. There is no explicit answer to “what user behaviour tells us this game is working?”
+- **Surface:** A visual language exists in code, but it is emergent. It may be enough for now, but should not be mistaken for a reusable design system.
 
-**Infrastructure constraint worth naming:** The prior app had load and data volume problems. The conceptual model decisions — how trades are recorded, how prices are calculated, how often — are directly coupled to infrastructure cost. These can't be designed in isolation from the cost constraint.
+**Cross-doc drift**
+
+- **Realtime price updates:** `docs/PRD.md`, `docs/pricing-formula.md`, and current code use Supabase row changes plus client-side derivation with no server-side ticker. `docs/tech-stack.md` and repo instructions still mention a configurable 2–3s server-side tick. Treat the no-ticker model as the implemented decision unless intentionally reversed.
+- **Anonymous survey handoff:** `docs/schema.md` says anonymous submissions are never retroactively linked to users; `docs/design/interaction-flow-survey.md` marks anonymous-to-signup carryover as the decision with implementation deferred. This needs one canonical product decision.
+- **Pricing constants:** Seed/admin docs provide practical defaults, but `docs/pricing-formula.md` still lists `base_price`, `K`, `MIN_SUPPLY_FLOOR`, `starting_balance`, and fee rate as TBD/open. Separate “default beta values” from “final calibration” so the docs stop reading as more undecided than the implementation is.
+- **Vocabulary leakage:** Some docs and code-facing copy still use “stock” and “P&L” in places where the current vocabulary says Contestant/Holding and plain-language gain/loss. This is a surface consistency issue rooted in the conceptual vocabulary decision.
 
 ---
 
 ## Recommendation
 
-Run **`/layers-conceptual-model`** next.
+Run **`/layers-observed-behaviour`** next.
 
-Specifically, we need to define:
-1. What are the core objects and their relationships
-2. What states each object moves through (especially Contestant/Stock lifecycle)
-3. The eviction event — what it does to Stock state, Portfolio state, and Leaderboard
-4. How a Trade works as an object — what it records, when it resolves, what it changes
-5. The Survey object and whether/how it connects to the Stock game
+The useful next move is not another broad design document. It is a lightweight research plan for the current product assumptions: what to learn from RHAP users, what to instrument in beta, and which behaviours would confirm or disconfirm the product strategy.
 
-Getting this documented will also generate the right questions to carry into the infrastructure and pricing formula conversations.
+Specific decisions to support:
 
-Want to run `/layers-conceptual-model` now, or push back on anything in this picture first?
+1. What evidence would show that 24/7 trading is better than trading windows?
+2. What do users need to understand about bonding-curve pricing before they trust it?
+3. Which loop matters most: trading, leaderboard comparison, survey results, or livestream reveal?
+4. What social behaviours should the product deliberately support in Discord/RHAP contexts?
+5. What success metric should guide v1: activation, repeat trading, survey completion, leaderboard checking, push opt-in, or something else?
+
+Want to run `/layers-observed-behaviour` now, or is there something in this picture to push back on first?
+
+---
+
+## Comparison To 2026-05-15 Orient
+
+| Area | 2026-05-15 finding | 2026-06-11 finding |
+|------|--------------------|--------------------|
+| Bottleneck | Conceptual Model | Observed Behaviour |
+| Conceptual model | Assumed; undocumented objects/states | Strong; documented and mostly implemented |
+| Interaction structure | Not started | Strong; key flows breadboarded and several shipped |
+| Surface | Not started | Partial; coherent shipped UI, no formal system |
+| Main risk | Build on undefined objects and states | Build on unvalidated assumptions about current-user behaviour |

--- a/docs/design/observed-behaviour.md
+++ b/docs/design/observed-behaviour.md
@@ -1,0 +1,122 @@
+# Observed Behaviour — Reality Stock Watch
+
+*Created: 2026-06-11. Framework: Layers of Product Design. Mode: partial synthesis, then research plan.*
+
+This layer records what we know, infer, and still assume about how users behave. It should stay close to evidence. Product conclusions belong in user needs or strategy docs.
+
+---
+
+## Evidence Inventory
+
+| Evidence | Confidence | What it suggests | Limits |
+|----------|------------|------------------|--------|
+| Prior version of the game had trading windows. | Observed from project history | Trading windows created enough friction that 24/7 trading is a deliberate replacement. | This was a different product model: windows plus audience-rating-based pricing, not a 24/7 bonding-curve market. |
+| Prior app had load and data-volume problems. | Observed from project history | Infrastructure cost and scale constraints should shape v1 choices. | This explains operational risk, not user motivation. |
+| Target audience is hardcore BB US fans, especially RHAP community. | Inferred from product brief | Users likely understand BB states, weekly cadence, live-feed discourse, and social comparison around reads. | Audience knowledge is not the same as product behaviour. |
+| Existing flow docs assume social competition and Discord bragging matter. | Assumed | Leaderboards, badges, public profile, and shareable stats may be important loops. | No direct research yet confirms which social mechanics are motivating. |
+| Weekly surveys and livestream reveal have been built into the product surface. | Observed in repo | Survey/result participation may be a major engagement loop beyond trading. | It is not yet clear whether users connect survey results to the trading game. |
+| Current implementation supports live price updates and at-market trades. | Observed in repo | Users will encounter price movement as a real-time, possibly trust-sensitive interaction. | No usability evidence yet shows whether users understand or trust the bonding curve. |
+
+---
+
+## Current Behavioural Assumptions
+
+| Assumption | Confidence | Why it matters |
+|------------|------------|----------------|
+| RHAP users want to put their reads on the line, not just discuss them. | Inferred | This justifies the trading game as more than a companion stats app. |
+| Users will tolerate or enjoy a market that is always open. | Assumed | If wrong, 24/7 trading could reduce urgency or create anxiety instead of engagement. |
+| A fake-money bonding curve will feel fair enough if explained through UI feedback. | Assumed | If wrong, price movement may feel arbitrary and undermine trust. |
+| Leaderboard rank and badges are motivating enough to drive return visits. | Assumed | This affects whether all-time ranking, badges, and profile work should get priority. |
+| Survey participation and result reveal reinforce the core game loop. | Assumed | If they are separate behaviours, survey/reveal work may need different success measures. |
+| Discord/RHAP sharing is a natural extension of use. | Assumed | This affects whether share cards, public profiles, and bragging affordances matter in v1. |
+
+---
+
+## Learning Goals
+
+The next observed-behaviour work should answer these questions:
+
+1. **Trading trigger:** What moment makes a BB fan want to act: episode result, live-feed spoiler, RHAP discussion, social pressure, price movement, or survey result?
+2. **Market trust:** What does a user need to see before they believe a trade price is fair and understandable?
+3. **Return loop:** What brings a user back after their first trade: checking prices, changing reads, leaderboard position, survey results, push notifications, or community conversation?
+4. **Social proof:** What do users naturally want to share, if anything: rank, portfolio value, best trade, contestant prediction, badge, survey take?
+5. **Survey relationship:** Do users experience weekly surveys as part of the market game, or as a parallel RHAP/community ritual?
+
+---
+
+## Recommended Research Plan
+
+### 1. JTBD Interviews With RHAP/BB Users
+
+Interview 6-10 likely users. Anchor each conversation in a real past behaviour, not hypothetical interest.
+
+Useful prompts:
+
+- Tell me about the last time you changed your mind about a Big Brother contestant.
+- What triggered that change?
+- Where did you talk about it or check whether other fans agreed?
+- Have you ever kept score, made predictions, joined a pool, ranked contestants, or compared reads with friends?
+- What made that fun, frustrating, or worth repeating?
+- When a fan game asks you to sign up, what makes it feel worth it?
+
+Capture one observation per note, tagged to the learning goal it speaks to. Use raw quotes where possible.
+
+### 2. Usability Observation On Current Build
+
+Give users a small set of tasks in the existing app:
+
+- Join or log in.
+- Find a contestant they believe is undervalued.
+- Place a buy trade.
+- Explain what happened to the price after the trade.
+- Find their holding and leaderboard position.
+- Take or review a survey if one is active.
+
+Watch for confusion, hesitation, missed affordances, and trust breaks. Do not explain the product unless the task depends on information not yet in the UI.
+
+### 3. Beta Analytics
+
+Instrument events that map to behaviour, not vanity traffic:
+
+- Account created.
+- Username confirmed.
+- First market view.
+- Contestant detail viewed.
+- Trade sheet opened.
+- Trade submitted.
+- Trade filled or failed.
+- Portfolio viewed after trade.
+- Leaderboard viewed.
+- Survey submitted.
+- Survey results viewed.
+- Push subscription accepted or declined.
+
+Pair analytics with qualitative notes. Analytics can show where users drop off, but not why.
+
+---
+
+## Candidate Observations To Validate
+
+These are not findings yet. Treat them as prompts for research.
+
+- Users may trade immediately after live-feed events rather than episode broadcasts.
+- Users may care more about beating known community members than climbing a global leaderboard.
+- Users may not need to understand the full bonding-curve formula, but they need to understand that buying moves price and selling can move proceeds.
+- Users may treat surveys as social proof for trades: "the community is underrating this contestant."
+- Users may want receipts for good reads, not just final-season badges.
+
+---
+
+## Research Gaps
+
+- No direct interviews with current target users are documented.
+- No usability observations of the current trade flow are documented.
+- No beta analytics plan is documented outside implementation-level event possibilities.
+- No evidence yet ranks trading, leaderboard, survey, livestream reveal, and Discord sharing as engagement loops.
+- No evidence yet shows whether users understand "Contestant" as the tradeable object without the word "stock."
+
+---
+
+## Handoff To User Needs
+
+The next `/layers-user-needs` pass should use this artifact to turn validated or high-confidence observations into candidate job stories. Until research exists, job stories should be marked **Assumed** or **Inferred**, not **Observed**.

--- a/docs/design/product-strategy.md
+++ b/docs/design/product-strategy.md
@@ -1,0 +1,148 @@
+# Product Strategy — Reality Stock Watch
+
+*Created: 2026-06-11. Framework: Layers of Product Design. Source: `docs/design/user-needs.md`.*
+
+This strategy is provisional because the underlying user needs are mostly inferred or assumed. Treat it as the clearest current bet, not as validated product truth.
+
+---
+
+## Strategic Bet
+
+Reality Stock Watch should optimize v1 around this core loop:
+
+> A BB fan gets new game information, forms or updates a read, trades on that read, and returns to see how that read compares with the market and community.
+
+Surveys, livestream reveal, leaderboard, badges, and push notifications should support that loop unless research shows they are valuable as separate rituals.
+
+---
+
+## Primary Outcome
+
+**Increase activated users who return after their first meaningful action during an active season.**
+
+For v1, a meaningful action is one of:
+
+- First filled Trade.
+- First Survey Response.
+- First published-results view after submitting a survey.
+
+The strongest activation signal is still expected to be a first filled Trade, because trading is the product's primary mechanic.
+
+---
+
+## Opportunity Tree
+
+| Journey moment | Opportunity | Confidence | Candidate bets |
+|----------------|-------------|------------|----------------|
+| New game information changes a fan's read | "I want to act before the rest of the fandom catches up." | Inferred | Fast trade entry, contestant detail context, current price movement, global trade affordance. |
+| User composes or submits a trade | "I need the trade to feel fair even if the market moved." | Assumed | Clear preview vs. execution feedback, plain-language price movement copy, visible fee/slippage summary. |
+| User returns after trading | "I want to know whether my read is paying off." | Inferred | Portfolio summary, holding-level gain/loss in plain language, trade history, contestant movement. |
+| User compares with community | "I want to see how I stack up without digging." | Inferred | Find-me leaderboard action, own-row treatment, rank movement, badges. |
+| Weekly fandom ritual | "I want to compare my take with the community." | Assumed | Survey result graph, livestream reveal, "Your picks" recall, push when results publish. |
+| Social sharing | "I want a receipt for my good read." | Assumed | Shareable rank/portfolio/best-trade card, public profile, badge detail. |
+
+---
+
+## Top Bets For V1
+
+### Bet 1: First Trade Activation
+
+**We could** make the first trade path fast, legible, and low-friction from market or contestant detail.
+
+**We believe this serves** the need to act on a changing read quickly.
+
+**Riskiest assumption:** users arrive with a contestant opinion strong enough to trade before they need deep explanation.
+
+**Cheapest tests:**
+
+- Usability test: ask 5 likely users to find a contestant they think is undervalued and place a trade.
+- Instrument: market view → trade sheet opened → trade submitted → trade filled.
+- Interview: ask what information they wanted before committing.
+
+### Bet 2: Trustworthy Market Feedback
+
+**We could** explain at-market execution through result feedback rather than long pre-trade education.
+
+**We believe this serves** the need to trust market movement while preserving speed.
+
+**Riskiest assumption:** users do not need the full formula if the trade result explains practical consequences clearly.
+
+**Cheapest tests:**
+
+- Usability test: after a trade, ask users to explain why the execution price may differ from preview.
+- Compare copy variants for filled trade feedback in a prototype.
+- Track failed trades and immediate repeat/retry behaviour.
+
+### Bet 3: Return Loop Through Portfolio And Community Comparison
+
+**We could** make Portfolio and Leaderboard the primary return destinations after first action.
+
+**We believe this serves** the need to see whether a read is paying off and compare with other fans.
+
+**Riskiest assumption:** users care about leaderboard comparison with mostly anonymous users.
+
+**Cheapest tests:**
+
+- Instrument first-action → portfolio view → leaderboard view within 24 hours.
+- Interview users about what result they would want to share after a good trade.
+- Prototype own-row/rank movement treatment and test whether it answers "how am I doing?"
+
+---
+
+## Deferred Bets
+
+These may be valuable, but should not lead v1 strategy until the core loop is validated:
+
+- Public profiles with full season history.
+- Friend groups or private leagues.
+- Price alerts for specific contestants.
+- Rich share cards for Discord/social channels.
+- Paid tier or subscription features.
+- Advanced pricing explainers or formula education.
+- All-time leaderboard scoring beyond basic season result snapshots.
+
+---
+
+## Success Metrics To Instrument
+
+Primary:
+
+- Activation rate: new account → first filled Trade.
+- Return rate: activated user returns within 24 hours and 7 days.
+- Repeat action rate: second Trade or second Survey Response in the same season.
+
+Supporting:
+
+- Trade sheet open → submit conversion.
+- Trade failure rate by reason.
+- Portfolio view after first Trade.
+- Leaderboard view after first Trade.
+- Survey submit → results view conversion.
+- Push opt-in rate after survey prompt.
+
+Guardrails:
+
+- High trade failure rate.
+- High abandonment at username confirmation.
+- High abandonment from trade sheet before submit.
+- Low comprehension in usability sessions around preview vs. execution.
+
+---
+
+## Strategy Risks
+
+- The chosen loop assumes trading is the primary value, but surveys/reveal may be the more natural RHAP ritual.
+- Social comparison may require known-community context rather than anonymous global rankings.
+- A 24/7 market may need event-based prompts to preserve urgency.
+- The product may need more pricing explanation than the current fast-trade loop allows.
+
+---
+
+## Handoff To Conceptual Model
+
+The current conceptual model mostly supports this strategy. The next audit should check four areas:
+
+1. Whether a **Trade** records enough information to create a user-facing "receipt" for a good read.
+2. Whether **Season Result** and **Badge** support the social proof users may want.
+3. Whether **Survey Response** should ever connect to a User after anonymous signup, since current docs disagree.
+4. Whether the model needs an explicit concept for rank movement, price movement, or notable trade events, or whether those remain derived views.

--- a/docs/design/surface-guidelines.md
+++ b/docs/design/surface-guidelines.md
@@ -1,0 +1,82 @@
+# Surface Guidelines — Reality Stock Watch
+
+*Created: 2026-06-11. Framework: Layers of Product Design. Source: conceptual model, interaction flows, and provisional product strategy.*
+
+These guidelines capture current surface decisions and cleanup targets. They are not a full design system.
+
+---
+
+## Surface Priorities
+
+1. **Fast comprehension:** users should understand the current season, current prices, their Cash, and the next trade action without reading a tutorial.
+2. **Market trust:** every Trade result should make clear what happened, what changed, and what the user can do next.
+3. **Plain competition:** show rank, Portfolio value, and gains/losses in direct language. Avoid finance jargon.
+4. **Community fit:** the tone should feel like a smart BB fan game, not a brokerage app.
+
+---
+
+## Vocabulary Rules
+
+Use the conceptual-model language:
+
+- User
+- Contestant
+- Trade
+- Holding
+- Portfolio
+- Cash
+- Season Result
+- Badge
+
+Avoid:
+
+- "Stock" as an object name. Prefer **Contestant** or **Contestant shares** when the share mechanic needs to be explicit.
+- "P&L". Prefer "up $247 since season start", "down $42 on this Holding", or "gain/loss".
+- "Order" unless a future queued-trade model makes that distinction visible to users.
+
+---
+
+## Feedback Rules
+
+| Action/state | Surface requirement |
+|--------------|---------------------|
+| Trade preview | Show estimated shares, price movement across the batch, fee, and clear language that execution is at-market. |
+| Trade processing | Block duplicate submit and show that the Trade is being placed. |
+| Trade filled | Confirm buy/sell, Contestant, shares, execution price, fee, and any meaningful preview difference. |
+| Trade failed | Diagnose the cause when known, explain the state of the user's money/Holding, and offer recovery. |
+| Price update | Animate subtly enough to signal change without making the market feel noisy. |
+| Empty Portfolio | Prompt first Trade using Contestant/Holding vocabulary. |
+| Leaderboard find-me | Make the user's own row visually distinct and explain if no rank exists yet. |
+
+---
+
+## Hierarchy Targets
+
+- **Market:** Contestant, current price, user Holding, and Trade affordance should dominate. Secondary flags like HoH/Nominated/Veto should be visible but not compete with price/action.
+- **Trade overlay:** amount, Buy/Sell, selected Contestant, and confirm action should be primary. Formula-level detail should stay secondary.
+- **Trade result:** outcome first, then executed details, then next action.
+- **Portfolio:** net worth, Cash, and change since season start first; individual Holdings second; history behind a tab.
+- **Leaderboard:** rank and username first; badges support the row, not dominate it.
+- **Survey results:** community result first; "Your picks" second; trading links only if they clarify the user's next decision.
+
+---
+
+## Open Surface Decisions
+
+- Homepage copy and season-aware logged-out state.
+- First-trade prompt or empty-state treatment for a new active-season user.
+- Contestant selector treatment inside the Trade overlay.
+- Price update animation threshold and style.
+- Trade result threshold for showing preview-vs-execution difference.
+- Badge visual treatment with season number.
+- Leaderboard "Find me" treatment when the user is outside the loaded range.
+- Whether survey results should include trade-adjacent calls to action.
+
+---
+
+## Deeper-Layer Issues To Avoid Patching At Surface
+
+- Anonymous survey handoff disagreement belongs to conceptual model and interaction flow first.
+- All-time leaderboard scoring belongs to product strategy and conceptual model before badge/profile UI.
+- If users do not trust pricing, do not solve only with more copy; revisit observed behaviour and trade interaction structure.
+- If users do not care about global rank, do not over-polish leaderboard visuals; revisit the social comparison strategy.

--- a/docs/design/user-needs.md
+++ b/docs/design/user-needs.md
@@ -1,0 +1,114 @@
+# User Needs — Reality Stock Watch
+
+*Created: 2026-06-11. Framework: Layers of Product Design. Source: current docs plus `docs/design/observed-behaviour.md`.*
+
+This document interprets observed behaviour and domain knowledge into candidate user needs. Because direct research for the current 24/7 version is not yet documented, most needs are **Inferred** or **Assumed**. Upgrade confidence only when supported by interviews, usability observation, analytics, or other direct evidence.
+
+---
+
+## Primary User Situation
+
+The primary user is a hardcore Big Brother fan in or near the RHAP community, during an active BB US season, who is following changing game information and wants a low-stakes way to act on, compare, and show their read of the season.
+
+Secondary situations:
+
+- A logged-out fan follows a public survey link and may not know the trading game exists.
+- A returning user checks whether their read, portfolio, or leaderboard position changed.
+- An admin/producer creates the conditions for weekly fan participation and livestream reveal moments.
+
+---
+
+## Priority Needs
+
+| Need | Type | Confidence | Why it matters |
+|------|------|------------|----------------|
+| Act on a changing read quickly. | Functional | Inferred | This is the core trading loop: a fan sees new game information and wants to turn that opinion into a stake before the moment passes. |
+| Trust that market movement is fair enough. | Emotional | Assumed | The bonding curve is central but abstract. If price shifts feel arbitrary, users may not trust wins, losses, or leaderboard rank. |
+| See whether my read is paying off. | Functional / emotional | Inferred | Portfolio value, holdings, trade history, and contestant movement answer whether a user's judgement is working. |
+| Compare myself with other fans. | Social | Inferred | Leaderboard, rank, badges, and public identity depend on this need being real. |
+| Share or defend my take in community context. | Social | Assumed | Discord/RHAP bragging is a likely motivation, but the exact shareable unit is not validated. |
+| Participate in weekly fan opinion rituals. | Social / emotional | Assumed | Surveys and livestream reveal may deepen engagement if users see them as part of the same fandom loop. |
+| Join without heavy explanation. | Functional / emotional | Inferred | The audience likely knows BB, but the app still needs to reduce signup and first-trade friction. |
+
+---
+
+## Candidate Job Stories
+
+### Trading
+
+| Job story | Confidence |
+|-----------|------------|
+| When new BB information changes my read on a contestant, I want to act on that read quickly, so I can feel like I got in before the rest of the fandom catches up. | Inferred |
+| When a price has already moved, I want to understand what changed, so I can decide whether the contestant still feels worth buying or selling. | Assumed |
+| When I place a trade, I want clear feedback about what actually executed, so I can trust the result even if the preview changed. | Inferred |
+| When I am wrong about a contestant, I want to see the consequence plainly, so I can decide whether to hold, sell, or double down. | Assumed |
+
+### Portfolio And Leaderboard
+
+| Job story | Confidence |
+|-----------|------------|
+| When I check back after game news or an episode, I want to see whether my portfolio moved, so I can tell if my reads are working. | Inferred |
+| When I want to compare myself with other fans, I want to find my rank quickly, so I can feel the competition without scanning a huge list. | Inferred |
+| When I finish high in a season, I want a visible record of that result, so I can carry proof of a good season into future games. | Assumed |
+| When I am not near the top, I still want a meaningful comparison point, so the leaderboard does not feel irrelevant. | Assumed |
+
+### Surveys And Reveal
+
+| Job story | Confidence |
+|-----------|------------|
+| When a weekly survey drops, I want to record my take on the season, so I can compare my read with the community later. | Inferred |
+| When results are published, I want to see how the community ranked contestants, so I can understand whether my read is mainstream or contrarian. | Inferred |
+| When survey rankings are revealed live, I want the reveal to feel like an event, so fan opinion becomes something worth watching together. | Assumed |
+| When I answer anonymously from a public link, I want the experience to be lightweight, so I can participate without committing to the full app. | Inferred |
+
+### Onboarding And Trust
+
+| Job story | Confidence |
+|-----------|------------|
+| When I first arrive from the RHAP community, I want to understand the basic promise immediately, so I can decide whether it is worth signing up. | Inferred |
+| When I create an account, I want a low-friction identity that still feels shareable, so I can participate without fussing over profile setup. | Inferred |
+| When I see fake money and market language, I want reassurance that there is no real-money risk, so the game stays fun rather than stressful. | Assumed |
+| When I encounter a failed or changed trade, I want the app to explain what happened in plain language, so I do not feel tricked by the system. | Inferred |
+
+---
+
+## Needs Not Yet Prioritized
+
+These needs have surfaced but should not drive strategy until validated or deliberately chosen:
+
+- Follow specific contestants independent of holdings.
+- Receive price alerts beyond survey-related push notifications.
+- Compare against friends or known RHAP community members rather than the whole leaderboard.
+- Show a public profile with best trades, badges, and season history.
+- Carry anonymous survey participation into a new account.
+- Understand the precise pricing formula rather than the practical consequences of trading.
+
+---
+
+## Contradictions To Watch
+
+- **Urgency vs. 24/7 availability:** An always-open market removes friction but may also reduce the event-like pressure that makes participation exciting.
+- **Finance metaphor vs. casual fandom:** Market mechanics create competition, but too much finance language can make the game feel colder or less accessible.
+- **Anonymous participation vs. account-based identity:** Surveys invite broad lightweight participation; trading and leaderboards require persistent identity.
+- **Community comparison vs. global leaderboard:** Users may care more about known social circles than anonymous rank.
+- **Explainability vs. speed:** Users want to act quickly, but at-market execution and bonding-curve movement require enough feedback to preserve trust.
+
+---
+
+## Research Gaps
+
+- Which candidate jobs are actually frequent and important for RHAP users?
+- Which social comparison object matters most: rank, badge, portfolio value, best trade, or prediction accuracy?
+- Does the weekly survey loop reinforce trading, or does it serve a separate fan ritual?
+- How much pricing explanation is enough for trust?
+- What makes a returning user open the app between episodes?
+
+---
+
+## Handoff To Product Strategy
+
+The product strategy pass should choose which of these needs v1 will optimize for. A reasonable provisional bet is:
+
+> Help BB fans act on changing reads and compare those reads socially, with enough market feedback to make results feel fair.
+
+That is still a strategic assumption until supported by observed behaviour.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10,7 +10,7 @@
 - [x] Audit conceptual model for strategy-driven gaps.
 - [x] Audit interaction structure and surface implications.
 - [x] Review docs for consistency.
-- [ ] Commit and push the documentation chunk.
+- [x] Commit and push the documentation chunk.
 
 ## Review
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,19 @@
+# Layers Flow Refinement
+
+## Plan
+
+- [x] Re-run `/layers-orient` against the current repo.
+- [x] Save a repo-level plan for refining the full layers flow.
+- [x] Create an observed-behaviour synthesis and research plan.
+- [x] Create a user-needs draft with confidence labels.
+- [x] Create a product-strategy draft with provisional v1 bets.
+- [x] Audit conceptual model for strategy-driven gaps.
+- [x] Audit interaction structure and surface implications.
+- [x] Review docs for consistency.
+- [ ] Commit and push the documentation chunk.
+
+## Review
+
+- `git diff --check` passes.
+- Design-doc vocabulary sweep leaves only intentional "do not use" and rejected-alternative references to Stock/P&L.
+- The only remaining server-side tick reference is the drift note in `docs/design/layers-orient.md`.


### PR DESCRIPTION
## Summary
- Re-ran the full Layers of Product Design flow for the repo and captured it in Markdown
- Added new docs for observed behaviour, user needs, product strategy, interaction flow audit, and surface guidelines
- Updated the existing conceptual model and flow docs to match current vocabulary and implementation decisions
- Logged the refinement workflow in `tasks/todo.md`

## Testing
- `git diff --check` passed
- Reviewed the updated design docs for vocabulary and cross-doc consistency
- Not run (not requested)